### PR TITLE
multiple linkout icons limit size stealing

### DIFF
--- a/app/presenters/drug_presenter.rb
+++ b/app/presenters/drug_presenter.rb
@@ -38,6 +38,6 @@ class DrugPresenter < SimpleDelegator
   end
 
   def publications
-    interactions.map{|i| i.publications}.flatten
+    interactions.map{|i| i.publications}.flatten.uniq
   end
 end

--- a/app/views/drugs/_drug_summary_tab.html.haml
+++ b/app/views/drugs/_drug_summary_tab.html.haml
@@ -23,9 +23,11 @@
             %td{style: "width: 300px"}=attribute.name
             %td{style: "width: 336px"}=attribute.value
       %div#linkouts
-        - drug.drug_claims.each do |dc|
+        - drug.drug_claims[0..3].each do |dc|
           %button{class: "button", type: "button", style:"background-color: #e7e7e7; border: none; margin-bottom: 4px", onclick:"location.href='#{dc.original_data_source_url}';"}
             = dc.source.source_db_name
+        %a#more{style: "display: inline-block; margin-left: 5px; cursor: pointer"}
+          = "(#{drug.drug_claims.count - 4} More Sources)"
 
     %div(class="item-panel")
       %h4
@@ -46,6 +48,11 @@
     $('#table_info')["0"].style.height = remaining + "px";
   })
   
+  $("a#more").click(function () {
+    $('a[href="' + "#" + "claims" + '"]').trigger('click');
+    return true;
+  }); 
+
 :css
   div button:hover {
       background-color: #330066!important;

--- a/app/views/genes/_gene_summary_tab.html.haml
+++ b/app/views/genes/_gene_summary_tab.html.haml
@@ -14,6 +14,7 @@
               =alt_name.alias
             %td{style: "text-align: right; width: 375px"}
               =alt_name.nomenclature
+
   %div{class: "cell category", style: "float: left; width: 50%" }
     %div{class: "item-panel", style:"margin-bottom: 10px"}
       %h4
@@ -26,9 +27,12 @@
             %td{style: "width: 336px"}
               =attribute.value
       %div#linkouts
-        - gene.gene_claims.each do |gc|
+        - gene.gene_claims[0..3].each do |gc|
           %button{class: "button", type: "button", style:"background-color: #e7e7e7; border: none; margin-bottom: 4px", onclick:"location.href='#{gc.original_data_source_url}';"}
             = gc.source.source_db_name
+        %a#more{style: "display: inline-block; margin-left: 5px; cursor: pointer"}
+          = "(#{gene.gene_claims.count - 4} More Sources)"
+
     %div(class="item-panel")
       %h4
         Publications:
@@ -48,6 +52,10 @@
     $('#table_info')["0"].style.height = remaining + "px";
   })
   
+  $("a#more").click(function () {
+    $('a[href="' + "#" + "claims" + '"]').trigger('click');
+    return true;
+  }); 
 :css
   div button:hover {
       background-color: #330066!important;


### PR DESCRIPTION
limit number of icons to one row so that the two columns stay the same height but the left boxes do not have to shrink considerably