### PR TITLE
TSV exports

### DIFF
--- a/app/assets/stylesheets/main.css.less
+++ b/app/assets/stylesheets/main.css.less
@@ -398,3 +398,16 @@ table.dataTable th:active {
     position: static;
   }
 }
+
+.export-button {
+  padding: 2px 6px;
+  font-size: 14px;
+  border-radius: 3px;
+  margin-top: 15px;
+  color: #333333;
+  background-color: #f5f5f5;
+  background-image: linear-gradient(to bottom, #fff, #e6e6e6);
+  border: 1px solid #cccccc;
+  border-bottom-color: #b3b3b3;
+  box-shadow: inset 0 1px 0 rgba(255,255,255,0.2), 0 1px 2px rgba(0,0,0,0.05);
+}

--- a/app/controllers/interaction_claims_controller.rb
+++ b/app/controllers/interaction_claims_controller.rb
@@ -79,9 +79,9 @@ class InteractionClaimsController < ApplicationController
           row_hash['match_term'] = identifiers.select { |i| i.id == id}.first.name
           row_hash['gene'] = interaction.gene.name
           row_hash['drug'] = interaction.drug.name
-          row_hash['interaction_types'] = interaction.interaction_types.pluck(:type).uniq.join(compound_field_separator)
-          row_hash['pmids'] = interaction.publications.pluck(:pmid).uniq.join(compound_field_separator)
-          row_hash['sources'] = interaction.sources.pluck(:source_db_name).uniq.join(compound_field_separator)
+          row_hash['interaction_types'] = interaction.type_names.join(compound_field_separator)
+          row_hash['pmids'] = interaction.pmids.join(compound_field_separator)
+          row_hash['sources'] = interaction.source_names.join(compound_field_separator)
           tsv << headers.map{ |field| row_hash[field] }
         end
       end

--- a/app/controllers/interaction_claims_controller.rb
+++ b/app/controllers/interaction_claims_controller.rb
@@ -71,17 +71,18 @@ class InteractionClaimsController < ApplicationController
             'match_type' => result.match_type_label,
             'search_term' => result.instance_variable_get(:@search_term)
         }
-        result.instance_variable_get(:@identifiers).each do |id|
-          row_hash['match_term'] = id.name
-          result.instance_variable_get(:@interactions).each do |interaction|
-            next unless id.id == interaction[match_field]
-            row_hash['gene'] = interaction.gene.name
-            row_hash['drug'] = interaction.drug.name
-            row_hash['interaction_types'] = interaction.interaction_types.pluck(:type).uniq.join(compound_field_separator)
-            row_hash['pmids'] = interaction.publications.pluck(:pmid).uniq.join(compound_field_separator)
-            row_hash['sources'] = interaction.interaction_claims.map{ |ic| ic.source.source_db_name }.uniq.join(compound_field_separator)
-            tsv << headers.map{ |field| row_hash[field] }
-          end
+        identifiers = result.instance_variable_get(:@identifiers)
+        # result.instance_variable_get(:@identifiers).each do |id|
+        #   row_hash['match_term'] = id.name
+        result.instance_variable_get(:@interactions).each do |interaction|
+          id = interaction[match_field]
+          row_hash['match_term'] = identifiers.select { |i| i.id == id}.first.name
+          row_hash['gene'] = interaction.gene.name
+          row_hash['drug'] = interaction.drug.name
+          row_hash['interaction_types'] = interaction.interaction_types.pluck(:type).uniq.join(compound_field_separator)
+          row_hash['pmids'] = interaction.publications.pluck(:pmid).uniq.join(compound_field_separator)
+          row_hash['sources'] = interaction.interaction_claims.map{ |ic| ic.source.source_db_name }.uniq.join(compound_field_separator)
+          tsv << headers.map{ |field| row_hash[field] }
         end
       end
     end

--- a/app/controllers/interaction_claims_controller.rb
+++ b/app/controllers/interaction_claims_controller.rb
@@ -81,7 +81,7 @@ class InteractionClaimsController < ApplicationController
           row_hash['drug'] = interaction.drug.name
           row_hash['interaction_types'] = interaction.interaction_types.pluck(:type).uniq.join(compound_field_separator)
           row_hash['pmids'] = interaction.publications.pluck(:pmid).uniq.join(compound_field_separator)
-          row_hash['sources'] = interaction.interaction_claims.map{ |ic| ic.source.source_db_name }.uniq.join(compound_field_separator)
+          row_hash['sources'] = interaction.sources.pluck(:source_db_name).uniq.join(compound_field_separator)
           tsv << headers.map{ |field| row_hash[field] }
         end
       end

--- a/app/controllers/interaction_claims_controller.rb
+++ b/app/controllers/interaction_claims_controller.rb
@@ -27,13 +27,9 @@ class InteractionClaimsController < ApplicationController
         combine_input_drugs(params)
       end
     end
-    @preset_fda = (params[:fda_approved_drug] == "checked" ? "FDA Approved" : "")
-    @preset_neo = (params[:anti_neoplastic] == "checked" ? "Anti-neoplastics" : "")
-    @preset_immuno = (params[:immunotherapy] == "checked" ? "Immunotherapies" : "")
-    @preset_clin = (params[:clinically_actionable] == "checked" ? "Clinically Actionable" : "")
-    @preset_druggable = (params[:druggable_genome] == "checked" ? "Druggable Genome" : "")
-    @preset_resist = (params[:drug_resistance] == "checked" ? "Drug Resistance" : "")
+    unpack_locals(params)
     perform_interaction_search
+    prepare_export
   end
 
   def interactions_for_related_genes
@@ -54,5 +50,40 @@ class InteractionClaimsController < ApplicationController
     validate_interaction_request(params)
     search_results = LookupInteractions.find(params)
     @search_results = InteractionSearchResultsPresenter.new(search_results, view_context)
+  end
+
+  def unpack_locals params
+    @preset_fda = (params[:fda_approved_drug] == "checked" ? "FDA Approved" : "")
+    @preset_neo = (params[:anti_neoplastic] == "checked" ? "Anti-neoplastics" : "")
+    @preset_immuno = (params[:immunotherapy] == "checked" ? "Immunotherapies" : "")
+    @preset_clin = (params[:clinically_actionable] == "checked" ? "Clinically Actionable" : "")
+    @preset_druggable = (params[:druggable_genome] == "checked" ? "Druggable Genome" : "")
+    @preset_resist = (params[:drug_resistance] == "checked" ? "Drug Resistance" : "")
+  end
+
+  def prepare_export(compound_field_separator = '|')
+    headers = %w[search_term match_term match_type gene drug interaction_types sources pmids]
+    @tsv = CSV.generate(col_sep: "\t") do |tsv|
+      tsv << headers
+      @search_results.instance_variable_get(:@search_results).each do |result|
+        match_field = result.instance_variable_get(:@type).singularize + '_id'
+        row_hash = {
+            'match_type' => result.match_type_label,
+            'search_term' => result.instance_variable_get(:@search_term)
+        }
+        result.instance_variable_get(:@identifiers).each do |id|
+          row_hash['match_term'] = id.name
+          result.instance_variable_get(:@interactions).each do |interaction|
+            next unless id.id == interaction[match_field]
+            row_hash['gene'] = interaction.gene.name
+            row_hash['drug'] = interaction.drug.name
+            row_hash['interaction_types'] = interaction.interaction_types.pluck(:type).uniq.join(compound_field_separator)
+            row_hash['pmids'] = interaction.publications.pluck(:pmid).uniq.join(compound_field_separator)
+            row_hash['sources'] = interaction.interaction_claims.map{ |ic| ic.source.source_db_name }.uniq.join(compound_field_separator)
+            tsv << headers.map{ |field| row_hash[field] }
+          end
+        end
+      end
+    end
   end
 end

--- a/app/controllers/interaction_claims_controller.rb
+++ b/app/controllers/interaction_claims_controller.rb
@@ -52,7 +52,7 @@ class InteractionClaimsController < ApplicationController
     @search_results = InteractionSearchResultsPresenter.new(search_results, view_context)
   end
 
-  def unpack_locals params
+  def unpack_locals(params)
     @preset_fda = (params[:fda_approved_drug] == "checked" ? "FDA Approved" : "")
     @preset_neo = (params[:anti_neoplastic] == "checked" ? "Anti-neoplastics" : "")
     @preset_immuno = (params[:immunotherapy] == "checked" ? "Immunotherapies" : "")
@@ -65,16 +65,14 @@ class InteractionClaimsController < ApplicationController
     headers = %w[search_term match_term match_type gene drug interaction_types sources pmids]
     @tsv = CSV.generate(col_sep: "\t") do |tsv|
       tsv << headers
-      @search_results.instance_variable_get(:@search_results).each do |result|
-        match_field = result.instance_variable_get(:@type).singularize + '_id'
+      @search_results.search_results.each do |result|
+        match_field = result.type.singularize + '_id'
         row_hash = {
             'match_type' => result.match_type_label,
-            'search_term' => result.instance_variable_get(:@search_term)
+            'search_term' => result.search_term
         }
-        identifiers = result.instance_variable_get(:@identifiers)
-        # result.instance_variable_get(:@identifiers).each do |id|
-        #   row_hash['match_term'] = id.name
-        result.instance_variable_get(:@interactions).each do |interaction|
+        identifiers = result.identifiers
+        result.interactions.each do |interaction|
           id = interaction[match_field]
           row_hash['match_term'] = identifiers.select { |i| i.id == id}.first.name
           row_hash['gene'] = interaction.gene.name

--- a/app/models/data_model/drug.rb
+++ b/app/models/data_model/drug.rb
@@ -15,7 +15,8 @@ module DataModel
 
 
     def self.for_search
-      eager_load(drug_claims: {interaction_claims: { source: [], gene_claim: [:source, :gene_claim_categories], interaction_claim_types: [], drug_claim: [drug: [drug_claims: [:drug_claim_types]]]}})
+      # eager_load(drug_claims: {interaction_claims: { source: [], gene_claim: [:source, :gene_claim_categories], interaction_claim_types: [], drug_claim: [drug: [drug_claims: [:drug_claim_types]]]}})
+      includes(interactions: [:gene, :interaction_types, :publications, :sources])
     end
 
     def self.for_show

--- a/app/models/data_model/drug.rb
+++ b/app/models/data_model/drug.rb
@@ -15,7 +15,6 @@ module DataModel
 
 
     def self.for_search
-      # eager_load(drug_claims: {interaction_claims: { source: [], gene_claim: [:source, :gene_claim_categories], interaction_claim_types: [], drug_claim: [drug: [drug_claims: [:drug_claim_types]]]}})
       includes(interactions: [:gene, :interaction_types, :publications, :sources])
     end
 

--- a/app/models/data_model/gene.rb
+++ b/app/models/data_model/gene.rb
@@ -15,7 +15,8 @@ module DataModel
     cache_query :all_gene_names, :all_gene_names
 
     def self.for_search
-      eager_load(gene_claims: {interaction_claims: { source: [], drug_claim: [:source], interaction_claim_types: [], gene_claim: [gene: [gene_claims: [:gene_claim_categories]]]}})
+      # eager_load(gene_claims: {interaction_claims: { source: [], drug_claim: [:source], interaction_claim_types: [], gene_claim: [gene: [gene_claims: [:gene_claim_categories]]]}})
+      includes(interactions: [:drug, :interaction_types, :publications, :sources])
     end
 
     def self.for_gene_categories

--- a/app/models/data_model/gene.rb
+++ b/app/models/data_model/gene.rb
@@ -15,7 +15,6 @@ module DataModel
     cache_query :all_gene_names, :all_gene_names
 
     def self.for_search
-      # eager_load(gene_claims: {interaction_claims: { source: [], drug_claim: [:source], interaction_claim_types: [], gene_claim: [gene: [gene_claims: [:gene_claim_categories]]]}})
       includes(interactions: [:drug, :interaction_types, :publications, :sources])
     end
 

--- a/app/models/data_model/interaction.rb
+++ b/app/models/data_model/interaction.rb
@@ -10,5 +10,6 @@ module DataModel
       :class_name => "InteractionClaimType"
     has_many :interaction_attributes
     has_and_belongs_to_many :publications
+    has_and_belongs_to_many :sources
   end
 end

--- a/app/models/data_model/interaction.rb
+++ b/app/models/data_model/interaction.rb
@@ -11,5 +11,17 @@ module DataModel
     has_many :interaction_attributes
     has_and_belongs_to_many :publications
     has_and_belongs_to_many :sources
+
+    def source_names
+      self.sources.pluck(:source_db_name).uniq
+    end
+
+    def type_names
+      self.interaction_types.pluck(:type).uniq
+    end
+
+    def pmids
+      self.publications.pluck(:pmid).uniq
+    end
   end
 end

--- a/app/views/interaction_claims/_interaction_search_failed.html.haml
+++ b/app/views/interaction_claims/_interaction_search_failed.html.haml
@@ -1,9 +1,6 @@
 - ambiguous_matches = ambiguous_results + ambiguous_no_interactions
 %div{style: "float: right; margin-top: -15px; width: 17%"}
-  = button_to 'interaction_search_results/download', {method: :post, class: 'button btn btn-mini export-button'} do
-    %i(class="fa fa-download" aria-hidden="true")
-      %span{style: "font-family: 'Helvetica Neue',Helvetica,Arial,sans-serif"}
-        Download as TSV
+  = render partial: 'shared/page_export'
   %div.well{style: "margin-top: 15px;"}
     %h3{style: "margin-top: -5px;"}
       Unmatched Terms
@@ -36,6 +33,7 @@
       - result[:identifiers].each do |entity|
         %li{class: "interaction interaction-panel", "data-category" => "interaction", "data-name" => "Interaction", id: entity.name + "-ambiguous", style: "display: list-item;"}
           = render partial: 'interaction_claims/interactions_search_panel', locals: { term: result[:term], entity: entity, filtered_interactions: result[:interactions] }
+
 :javascript
   function toggleIcon(e) {
     $(e.target)

--- a/app/views/interaction_claims/_interaction_search_failed.html.haml
+++ b/app/views/interaction_claims/_interaction_search_failed.html.haml
@@ -1,5 +1,9 @@
 - ambiguous_matches = ambiguous_results + ambiguous_no_interactions
 %div{style: "float: right; margin-top: -15px; width: 17%"}
+  = button_to 'interaction_search_results/download', {method: :post, class: 'button btn btn-mini export-button'} do
+    %i(class="fa fa-download" aria-hidden="true")
+      %span{style: "font-family: 'Helvetica Neue',Helvetica,Arial,sans-serif"}
+        Download as TSV
   %div.well{style: "margin-top: 15px;"}
     %h3{style: "margin-top: -5px;"}
       Unmatched Terms

--- a/app/views/interaction_claims/_interaction_search_successful.html.haml
+++ b/app/views/interaction_claims/_interaction_search_successful.html.haml
@@ -1,9 +1,6 @@
 - definite_matches = definite_results + definite_no_interactions
 %div{style: "float: right; margin-top: -15px; width: 17%"}
-  = button_to 'interaction_search_results/download', {method: :post, class: 'button btn btn-mini export-button'} do
-  %i(class="fa fa-download" aria-hidden="true")
-    %span{style: "font-family: 'Helvetica Neue',Helvetica,Arial,sans-serif"}
-      Download as TSV
+  = render partial: 'shared/page_export'
   %div.alert.alert-error.well{style: "margin-top: 15px; padding-right: 20px; width: 240px;"}
     %h3{style: "margin-top: -5px;"}
       Preset Filters

--- a/app/views/interaction_claims/_interaction_search_successful.html.haml
+++ b/app/views/interaction_claims/_interaction_search_successful.html.haml
@@ -1,5 +1,9 @@
 - definite_matches = definite_results + definite_no_interactions
 %div{style: "float: right; margin-top: -15px; width: 17%"}
+  = button_to 'interaction_search_results/download', {method: :post, class: 'button btn btn-mini export-button'} do
+  %i(class="fa fa-download" aria-hidden="true")
+    %span{style: "font-family: 'Helvetica Neue',Helvetica,Arial,sans-serif"}
+      Download as TSV
   %div.alert.alert-error.well{style: "margin-top: 15px; padding-right: 20px; width: 240px;"}
     %h3{style: "margin-top: -5px;"}
       Preset Filters

--- a/app/views/shared/_page_export.html.haml
+++ b/app/views/shared/_page_export.html.haml
@@ -1,0 +1,5 @@
+= button_to '/download_table', {method: :post, class: 'button btn btn-mini export-button',
+                                params: {'file_contents' => 'hello world'}} do
+  %i(class="fa fa-download" aria-hidden="true")
+    %span{style: "font-family: 'Helvetica Neue',Helvetica,Arial,sans-serif"}
+      Download as TSV

--- a/app/views/shared/_page_export.html.haml
+++ b/app/views/shared/_page_export.html.haml
@@ -1,5 +1,5 @@
 = button_to '/download_table', {method: :post, class: 'button btn btn-mini export-button',
-                                params: {'file_contents' => 'hello world'}} do
+                                params: {'file_contents' => @tsv}} do
   %i(class="fa fa-download" aria-hidden="true")
     %span{style: "font-family: 'Helvetica Neue',Helvetica,Arial,sans-serif"}
       Download as TSV

--- a/db/migrate/20170705222429_create_join_table_interaction_source.rb
+++ b/db/migrate/20170705222429_create_join_table_interaction_source.rb
@@ -1,0 +1,15 @@
+class CreateJoinTableInteractionSource < ActiveRecord::Migration[5.1]
+  def up
+    create_table :interactions_sources, id: false do |t|
+      t.text :interaction_id, null: false
+      t.text :source_id, null: false
+    end
+    execute 'ALTER TABLE interactions_sources ADD PRIMARY KEY (interaction_id, source_id)'
+    execute 'ALTER TABLE interactions_sources ADD CONSTRAINT fk_interaction FOREIGN KEY (interaction_id) REFERENCES interactions(id)'
+    execute 'ALTER TABLE interactions_sources ADD CONSTRAINT fk_source FOREIGN KEY (source_id) REFERENCES sources(id)'
+  end
+
+  def down
+    drop_table :interactions_sources
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -541,6 +541,16 @@ CREATE TABLE interactions_publications (
 
 
 --
+-- Name: interactions_sources; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE interactions_sources (
+    interaction_id text NOT NULL,
+    source_id text NOT NULL
+);
+
+
+--
 -- Name: publications; Type: TABLE; Schema: public; Owner: -
 --
 
@@ -922,6 +932,14 @@ ALTER TABLE ONLY interactions
 
 ALTER TABLE ONLY interactions_publications
     ADD CONSTRAINT interactions_publications_pkey PRIMARY KEY (interaction_id, publication_id);
+
+
+--
+-- Name: interactions_sources interactions_sources_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY interactions_sources
+    ADD CONSTRAINT interactions_sources_pkey PRIMARY KEY (interaction_id, source_id);
 
 
 --
@@ -1619,6 +1637,14 @@ ALTER TABLE ONLY interactions_publications
 
 
 --
+-- Name: interactions_sources fk_interaction; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY interactions_sources
+    ADD CONSTRAINT fk_interaction FOREIGN KEY (interaction_id) REFERENCES interactions(id);
+
+
+--
 -- Name: interaction_attributes_sources fk_interaction_attribute; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -1723,6 +1749,14 @@ ALTER TABLE ONLY interaction_attributes_sources
 
 
 --
+-- Name: interactions_sources fk_source; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY interactions_sources
+    ADD CONSTRAINT fk_source FOREIGN KEY (source_id) REFERENCES sources(id);
+
+
+--
 -- Name: drug_claims fk_source_id; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -1813,6 +1847,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20170622142108'),
 ('20170628044755'),
 ('20170629024912'),
-('20170630203634');
+('20170630203634'),
+('20170705222429');
 
 

--- a/lib/genome/groupers/interaction_grouper.rb
+++ b/lib/genome/groupers/interaction_grouper.rb
@@ -43,6 +43,10 @@ module Genome
       def self.add_attributes
         DataModel::Interaction.all.each do |interaction|
           interaction.interaction_claims.each do |interaction_claim|
+            # roll sources up to interaction level
+            unless interaction.sources.include? interaction_claim.source
+              interaction.sources << interaction_claim.source
+            end
             interaction_claim.interaction_claim_attributes.each do |ica|
               interaction_attribute = DataModel::InteractionAttribute.where(
                 interaction_id: interaction.id,

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -17,6 +17,7 @@ require 'capybara/rails'
 # in spec/support/ and its subdirectories.
 Dir[Rails.root.join("spec/support/**/*.rb")].each {|f| require f}
 
+ActiveRecord::Migration.maintain_test_schema!
 
 RSpec.configure do |config|
   config.before(:suite) do


### PR DESCRIPTION
Our old method of exporting a TSV using jquery datatables no longer works with our 3.0 views. This PR creates a new method for constructing a TSV string from the result data, and leverages the existing utility for generating and returning the file from the string.

This PR is not ready for merging. It requires some optimization (interaction source roll-up and eager loading) of the objects returned by the interaction search. However, it would be good to do a quick review of the existing code to ensure that nothing dangerous/ill-conceived is going on here.