### PR TITLE
Online updater for Ensembl

### DIFF
--- a/app/jobs/update_ensembl.rb
+++ b/app/jobs/update_ensembl.rb
@@ -1,0 +1,66 @@
+require "net/ftp"
+
+class UpdateEnsembl < TsvUpdater
+  def tempfile_name
+    ['gene_txt.gz', '.gz']
+  end
+
+  def importer
+    Genome::Importers::Ensembl::NewEnsembl.new(tempfile, latest_version)
+  end
+
+  def latest_version
+    potential_version = 89
+    until remote_exists?(path_for_version(potential_version)) || potential_version > 100
+      potential_version += 1
+    end
+    return "#{potential_version}_38"
+  end
+
+  def latest_url
+    potential_version = 89
+    until remote_exists?(path_for_version(potential_version)) || potential_version > 100
+      potential_version += 1
+    end
+    return uri_for_version(potential_version)
+  end
+
+  def path_for_version(version)
+    "pub/current_gtf/homo_sapiens/Homo_sapiens.GRCh38.#{version}.gtf.gz"
+  end
+
+  def uri_for_version(version)
+    "ftp://ftp.ensembl.org/pub/current_gtf/homo_sapiens/Homo_sapiens.GRCh38.#{version}.gtf.gz"
+  end
+
+  def remote_exists?(uri)
+    ftp = Net::FTP.new("ftp.ensembl.org")
+    ftp.login
+    begin
+      ftp.size(uri)
+    rescue Net::FTPPermError
+      return false
+    end
+
+    true
+  end
+
+  def next_update_time
+    Date.today
+      .beginning_of_week
+      .next_month
+      .midnight
+  end
+
+  def should_group_genes?
+    true
+  end
+
+  def should_group_drugs?
+    false
+  end
+
+  def should_cleanup_gene_claims?
+    true
+  end
+end

--- a/lib/genome/importers/ensembl/new_ensembl.rb
+++ b/lib/genome/importers/ensembl/new_ensembl.rb
@@ -1,0 +1,80 @@
+module Genome; module Importers; module Ensembl;
+  class NewEnsembl
+    attr_reader :file_path, :source, :version
+    def initialize(file_path, version)
+      @file_path = file_path
+      @version = version
+    end
+
+    def import
+      remove_existing_source
+      create_source
+      import_symbols
+    end
+
+    private
+    def remove_existing_source
+      Utils::Database.delete_source('Ensembl')
+    end
+
+    def create_source
+      @source = DataModel::Source.where(
+        base_url:           'http://useast.ensembl.org/Homo_sapiens/Gene/Summary?g=',
+        site_url:           'http://ensembl.org/index.html',
+        citation:           'Ensembl 2011. Flicek P, Amode MR, ..., Vogel J, Searle SM. Nucleic Acids Res. 2011 Jan;39(Database issue)800-6. Epub 2010 Nov 2. PMID: 21045057.',
+        source_db_version:  version,
+        source_type_id:     DataModel::SourceType.GENE,
+        source_db_name:     'Ensembl',
+        full_name:          'Ensembl'
+      ).first_or_create
+    end
+
+    def import_symbols
+#      ActiveRecord::Base.transaction do
+        File.open(file_path, 'r') do |file|
+          reader = Zlib::GzipReader.new(file, encoding: "iso-8859-1:UTF-8")
+          CSV.new(reader, col_sep: "\t", headers: headers, quote_char: "'", skip_lines: /^#!/).each do |line|
+            next unless valid_line?(line)
+            process_line(line)
+          end
+          reader.close
+        end
+#      end
+    end
+
+    def headers
+      ['seqname', 'source', 'feature', 'start', 'end', 'score', 'strand', 'frame', 'attribute']
+    end
+
+    def valid_line?(line)
+      line['feature'] == 'gene'
+    end
+
+    def process_line(line)
+      attributes = line['attribute'].split('; ')
+      attribute_hash = {}
+      attributes.each do |a|
+        (key, value) = a.split(' ')
+        attribute_hash[key] = value[1..-2] #Stripe quotes
+      end
+
+      gene_claim = DataModel::GeneClaim.where(
+        name: attribute_hash['gene_id'].upcase,
+        nomenclature: 'Ensembl Gene Id',
+        source_id: source.id,
+      ).first_or_create
+
+      gene_claim_alias = DataModel::GeneClaimAlias.where(
+        alias: attribute_hash['gene_name'].upcase,
+        nomenclature: 'Ensembl Gene Name',
+        gene_claim_id: gene_claim.id,
+      ).first_or_create
+
+      gene_claim_attribute = DataModel::GeneClaimAttribute.where(
+        name: 'Gene Biotype',
+        value: attribute_hash['gene_biotype'].upcase,
+        gene_claim_id: gene_claim.id,
+      ).first_or_create
+    end
+  end
+end; end; end


### PR DESCRIPTION
This is slightly different to the old Ensembl updater in that it doesn't create a gene claim alias for the Ensembl Gene Id. I left that out since it seemed redundant.