### PR TITLE
Missing chembl molecules

### DIFF
--- a/app/jobs/post_grouper.rb
+++ b/app/jobs/post_grouper.rb
@@ -2,10 +2,10 @@
 class PostGrouper
   def perform(cleanup_gene_claims = false)
     if cleanup_gene_claims
-      delete_orphaned_gene_claims()
+      delete_orphaned_gene_claims
     end
-    update_counts()
-    update_trust_levels()
+    update_counts
+    update_trust_levels
   end
 
   def delete_orphaned_gene_claims
@@ -15,10 +15,15 @@ class PostGrouper
   end
 
   def update_counts
-    Genome::Normalizers::PopulateCounters.populate_source_counters()
+    Genome::Normalizers::PopulateCounters.populate_source_counters
   end
 
   def update_trust_levels
-    Genome::Normalizers::SourceTrustLevel.populate_trust_levels()
+    Genome::Normalizers::SourceTrustLevel.populate_trust_levels
   end
+
+  def update_drug_types
+    Genome::Normalizers::DrugTypeNormalizers.normalize_types
+  end
+
 end

--- a/app/models/data_model/chembl_molecule.rb
+++ b/app/models/data_model/chembl_molecule.rb
@@ -1,6 +1,6 @@
 module DataModel
   class ChemblMolecule < ActiveRecord::Base
-    belongs_to :drug
+    has_one :drug
     has_many :chembl_molecule_synonyms
 
     def names

--- a/app/models/data_model/drug.rb
+++ b/app/models/data_model/drug.rb
@@ -7,10 +7,9 @@ module DataModel
     has_many :interactions
     has_many :drug_aliases
     has_many :drug_attributes
-    has_one :chembl_molecule
+    belongs_to :chembl_molecule
 
     before_create :populate_flags
-    after_destroy :clean_molecule
 
     cache_query :all_drug_names, :all_drug_names
 
@@ -40,10 +39,6 @@ module DataModel
       end
       self.immunotherapy = false
       self.anti_neoplastic = false
-    end
-
-    def clean_molecule
-      self.chembl_molecule.drug_id = nil
     end
 
     def update_anti_neoplastic_add(drug_claim)

--- a/db/migrate/20170824182356_revise_constraints_of_chembl_molecules.rb
+++ b/db/migrate/20170824182356_revise_constraints_of_chembl_molecules.rb
@@ -1,0 +1,8 @@
+class ReviseConstraintsOfChemblMolecules < ActiveRecord::Migration[5.1]
+  def change
+    remove_foreign_key :chembl_molecules, :drugs
+    remove_column :chembl_molecules, :drug_id
+    add_column :drugs, :chembl_molecule_id, :integer
+    add_foreign_key :drugs, :chembl_molecules
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -107,8 +107,7 @@ CREATE TABLE chembl_molecules (
     withdrawn_flag boolean,
     withdrawn_year integer,
     withdrawn_country text,
-    withdrawn_reason text,
-    drug_id text
+    withdrawn_reason text
 );
 
 
@@ -281,7 +280,8 @@ CREATE TABLE drugs (
     fda_approved boolean,
     immunotherapy boolean,
     anti_neoplastic boolean,
-    chembl_id character varying NOT NULL
+    chembl_id character varying NOT NULL,
+    chembl_molecule_id integer
 );
 
 
@@ -1170,13 +1170,6 @@ CREATE UNIQUE INDEX index_chembl_molecules_on_chembl_id ON chembl_molecules USIN
 
 
 --
--- Name: index_chembl_molecules_on_drug_id; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX index_chembl_molecules_on_drug_id ON chembl_molecules USING btree (drug_id);
-
-
---
 -- Name: index_chembl_molecules_on_molregno; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -1771,11 +1764,11 @@ ALTER TABLE ONLY drug_aliases
 
 
 --
--- Name: chembl_molecules fk_rails_4d99531977; Type: FK CONSTRAINT; Schema: public; Owner: -
+-- Name: drugs fk_rails_de0c74dec1; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY chembl_molecules
-    ADD CONSTRAINT fk_rails_4d99531977 FOREIGN KEY (drug_id) REFERENCES drugs(id);
+ALTER TABLE ONLY drugs
+    ADD CONSTRAINT fk_rails_de0c74dec1 FOREIGN KEY (chembl_molecule_id) REFERENCES chembl_molecules(id);
 
 
 --
@@ -1925,5 +1918,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20170728015708'),
 ('20170728023124'),
 ('20170729004221'),
-('20170808210937');
+('20170808210937'),
+('20170824182356');
+
 

--- a/lib/genome/groupers/interaction_grouper.rb
+++ b/lib/genome/groupers/interaction_grouper.rb
@@ -13,10 +13,7 @@ module Genome
       end
 
       def self.reset_members
-        DataModel::InteractionClaim.all.each do |interaction_claim|
-          interaction_claim.interaction = nil
-          interaction_claim.save
-        end
+        DataModel::InteractionClaim.update_all(interaction: nil)
         DataModel::InteractionAttribute.destroy_all
         DataModel::Interaction.destroy_all
       end

--- a/lib/genome/groupers/interaction_grouper.rb
+++ b/lib/genome/groupers/interaction_grouper.rb
@@ -13,7 +13,7 @@ module Genome
       end
 
       def self.reset_members
-        DataModel::InteractionClaim.update_all(interaction: nil)
+        DataModel::InteractionClaim.update_all(interaction_id: nil)
         DataModel::InteractionAttribute.destroy_all
         DataModel::Interaction.destroy_all
       end


### PR DESCRIPTION
@susannasiebert mentioned we were missing chembl molecules. I think that they were accidentally removed as part of a delete cascade. I've adjusted the models such that the foreign key is now in the `drug` table, which should prevent this behavior from occurring in the future.