### PR TITLE
Use identifier instead of results for matched terms properties

### DIFF
--- a/app/presenters/interaction_search_result_api_v1_presenter.rb
+++ b/app/presenters/interaction_search_result_api_v1_presenter.rb
@@ -5,6 +5,10 @@ class InteractionSearchResultApiV1Presenter
     @interactions = interactions.flat_map(&:interaction_claims).map{|i| InteractionWrapper.new(i)}
   end
 
+  def identifier
+    @identifier
+  end
+
   def search_term
     @result.search_term
   end
@@ -26,7 +30,7 @@ class InteractionSearchResultApiV1Presenter
   end
 
   def potentially_druggable_categories
-    gene.gene_claims.flat_map { |gc| gc.gene_claim_categories }
+    @identifier.gene_claims.flat_map { |gc| gc.gene_claim_categories }
     .map { |c| c.name }
     .uniq
   end

--- a/app/views/services_v1/interactions.json.jbuilder
+++ b/app/views/services_v1/interactions.json.jbuilder
@@ -1,7 +1,7 @@
 json.matchedTerms @search_results.matched_results do |result|
   if result.type == 'drugs'
     json.searchTerm result.search_term
-    json.drugName result.drug_name
+    json.drugName result.identifier.name
     json.interactions result.interactions do |interaction|
       json.interactionId interaction.interaction_id
       json.interactionType interaction.types_string
@@ -11,8 +11,8 @@ json.matchedTerms @search_results.matched_results do |result|
     end
   else
     json.searchTerm result.search_term
-    json.geneName result.gene_name
-    json.geneLongName result.gene_long_name
+    json.geneName result.identifier.name
+    json.geneLongName result.identifier.long_name
     json.geneCategories result.potentially_druggable_categories
     json.interactions result.interactions do |interaction|
       json.interactionId interaction.interaction_id


### PR DESCRIPTION
This fixes an error that would occur if the search yields a match without any interactions. Previously, we would try to determine the gene or drug from the list of interactions. With this PR we will instead use the `identifier` which is the object matched to the search term.