### PR TITLE
Strip names/attributes/aliases/etc of leading and trailing whitespaces

### DIFF
--- a/app/jobs/post_grouper.rb
+++ b/app/jobs/post_grouper.rb
@@ -8,6 +8,7 @@ class PostGrouper
     update_trust_levels
     update_drug_types
     backfill_publications
+    generate_tsvs
     Rails.cache.clear
   end
 
@@ -31,5 +32,12 @@ class PostGrouper
 
   def backfill_publications
     Genome::Normalizers::Publications.populate_interaction_claims
+  end
+
+  def generate_tsvs
+    Utils::TSV.generate_categories_tsv
+    Utils::TSV.generate_interactions_tsv
+    Utils::TSV.generate_genes_tsv
+    Utils::TSV.generate_drugs_tsv
   end
 end

--- a/lib/genome/importers/drug_bank/new_drug_bank.rb
+++ b/lib/genome/importers/drug_bank/new_drug_bank.rb
@@ -14,7 +14,7 @@ module Genome; module Importers; module DrugBank;
     end
 
     def get_version
-      File.open('lib/genome/updaters/data/version').readlines.each do |line|
+      File.open('tmp/version').readlines.each do |line|
         source, version = line.split("\t")
         if source == 'DrugBank'
           return version.strip

--- a/lib/genome/online_updater.rb
+++ b/lib/genome/online_updater.rb
@@ -73,6 +73,7 @@ module Genome
       if publication.citation.nil?
         publication.citation = PMID.get_citation_from_pubmed_id(pmid)
         publication.save
+        sleep(1)
       end
       interaction_claim.publications << publication unless interaction_claim.publications.include? publication
     end

--- a/lib/genome/online_updater.rb
+++ b/lib/genome/online_updater.rb
@@ -2,33 +2,33 @@ module Genome
   class OnlineUpdater
     def create_gene_claim(gene_name, nomenclature)
       DataModel::GeneClaim.where(
-        name: gene_name,
-        nomenclature: nomenclature,
+        name: gene_name.strip(),
+        nomenclature: nomenclature.strip(),
         source_id: @source.id
       ).first_or_create
     end
 
     def create_gene_claim_alias(gene_claim, synonym, nomenclature)
       DataModel::GeneClaimAlias.where(
-        alias: synonym,
-        nomenclature: nomenclature,
+        alias: synonym.to_s.strip(),
+        nomenclature: nomenclature.strip(),
         gene_claim_id: gene_claim.id,
       ).first_or_create
     end
 
     def create_gene_claim_attribute(gene_claim, name, value)
       DataModel::GeneClaimAttribute.where(
-        name: name,
-        value: value,
+        name: name.strip(),
+        value: value.strip(),
         gene_claim_id: gene_claim.id,
       ).first_or_create
     end
 
     def create_drug_claim(name, primary_name, nomenclature)
       DataModel::DrugClaim.where(
-        name: name,
-        primary_name: primary_name,
-        nomenclature: nomenclature,
+        name: name.strip(),
+        primary_name: primary_name.strip(),
+        nomenclature: nomenclature.strip(),
         source_id: @source.id,
       ).first_or_create
     end
@@ -37,16 +37,16 @@ module Genome
       cleaned = synonym.gsub(/[^\w_]+/,'').upcase
       return nil unless DataModel::DrugAliasBlacklist.find_by(alias: cleaned).nil?
       DataModel::DrugClaimAlias.where(
-        alias: synonym,
-        nomenclature: nomenclature,
+        alias: synonym.strip(),
+        nomenclature: nomenclature.strip(),
         drug_claim_id: drug_claim.id,
       ).first_or_create
     end
 
     def create_drug_claim_attribute(drug_claim, name, value)
       DataModel::DrugClaimAttribute.where(
-        name: name,
-        value: value,
+        name: name.strip(),
+        value: value.strip(),
         drug_claim_id: drug_claim.id
       ).first_or_create
     end
@@ -61,7 +61,7 @@ module Genome
 
     def create_interaction_claim_type(interaction_claim, type)
       claim_type = DataModel::InteractionClaimType.where(
-        type: type
+        type: type.strip()
       ).first_or_create
       interaction_claim.interaction_claim_types << claim_type unless interaction_claim.interaction_claim_types.include? claim_type
     end
@@ -79,8 +79,8 @@ module Genome
 
     def create_interaction_claim_attribute(interaction_claim, name, value)
       DataModel::InteractionClaimAttribute.where(
-        name: name,
-        value: value,
+        name: name.to_s.strip(),
+        value: value.strip(),
         interaction_claim_id: interaction_claim.id
       ).first_or_create
     end

--- a/lib/utils/database.rb
+++ b/lib/utils/database.rb
@@ -258,6 +258,14 @@ module Utils
         a.value = a.value.strip
         a.save!
       end
+      DataModel::InteractionAttribute.where("name LIKE ' %' or name LIKE '% '").all.each do |a|
+        a.name = a.name.strip
+        a.save!
+      end
+      DataModel::InteractionAttribute.where("value LIKE ' %' or value LIKE '% '").all.each do |a|
+        a.value = a.value.strip
+        a.save!
+      end
 
       DataModel::GeneClaimAlias.where("alias LIKE ' %' or alias LIKE '% '").all.each do |a|
         a.alias = a.alias.strip
@@ -270,6 +278,35 @@ module Utils
       DataModel::GeneClaimAttribute.where("value LIKE ' %' or value LIKE '% '").all.each do |a|
         a.value = a.value.strip
         a.save!
+      end
+      DataModel::GeneAlias.where("alias LIKE ' %' or alias LIKE '% '").all.each do |a|
+        clean_alias = a.alias.strip
+        if (clean_gene_alias = DataModel::GeneAlias.where('upper(alias) = ? and gene_id = ?', clean_alias.upcase, a.gene_id)).one?
+          a.sources.each do |source|
+            clean_gene_alias.first.sources << source unless clean_gene_alias.first.sources.include? source
+            a.sources.delete(source)
+          end
+          a.delete
+        else
+          a.alias = clean_alias
+          a.save!
+        end
+      end
+      DataModel::GeneAttribute.where("name LIKE ' %' or name LIKE '% '").all.each do |a|
+        clean_attribute = DataModel::GeneAttribute.where(name: a.name.strip, value: a.value.strip, gene_id: a.gene_id).first_or_create
+        a.sources.each do |source|
+          clean_attribute.sources << source unless clean_attribute.sources.include? source
+          a.sources.delete(source)
+        end
+        a.delete
+      end
+      DataModel::GeneAttribute.where("value LIKE ' %' or value LIKE '% '").all.each do |a|
+        clean_attribute = DataModel::GeneAttribute.where(name: a.name.strip, value: a.value.strip, gene_id: a.gene_id).first_or_create
+        a.sources.each do |source|
+          clean_attribute.sources << source unless clean_attribute.sources.include? source
+          a.sources.delete(source)
+        end
+        a.delete
       end
       DataModel::GeneClaim.where("name LIKE ' %' or name LIKE '% '").all.each do |c|
         clean_name = c.name.strip
@@ -307,6 +344,27 @@ module Utils
         a.save!
       end
       DataModel::DrugClaimAttribute.where("value LIKE ' %' or value LIKE '% '").all.each do |a|
+        a.value = a.value.strip
+        a.save!
+      end
+      DataModel::DrugAlias.where("alias LIKE ' %' or alias LIKE '% '").all.each do |a|
+        clean_alias = a.alias.strip
+        if (clean_drug_alias = DataModel::DrugAlias.where('alias ILIKE ? and drug_id = ?', clean_alias, a.drug_id)).one?
+          a.sources.each do |source|
+            clean_drug_alias.first.sources << source unless clean_drug_alias.first.sources.include? source
+            a.sources.delete(source)
+          end
+          a.delete
+        else
+          a.alias = clean_alias
+          a.save!
+        end
+      end
+      DataModel::DrugAttribute.where("name LIKE ' %' or name LIKE '% '").all.each do |a|
+        a.name = a.name.strip
+        a.save!
+      end
+      DataModel::DrugAttribute.where("value LIKE ' %' or value LIKE '% '").all.each do |a|
         a.value = a.value.strip
         a.save!
       end

--- a/lib/utils/database.rb
+++ b/lib/utils/database.rb
@@ -244,5 +244,98 @@ module Utils
         end
       end
     end
+
+    def self.cleanup_whitespaces
+      DataModel::InteractionClaimType.where("type lIKE ' %' or type LIKE '% '").all.each do |t|
+        t.value = t.value.strip
+        t.save!
+      end
+      DataModel::InteractionClaimAttribute.where("name LIKE ' %' or name LIKE '% '").all.each do |a|
+        a.name = a.name.strip
+        a.save!
+      end
+      DataModel::InteractionClaimAttribute.where("value LIKE ' %' or value LIKE '% '").all.each do |a|
+        a.value = a.value.strip
+        a.save!
+      end
+
+      DataModel::GeneClaimAlias.where("alias LIKE ' %' or alias LIKE '% '").all.each do |a|
+        a.alias = a.alias.strip
+        a.save!
+      end
+      DataModel::GeneClaimAttribute.where("name LIKE ' %' or name LIKE '% '").all.each do |a|
+        a.name = a.name.strip
+        a.save!
+      end
+      DataModel::GeneClaimAttribute.where("value LIKE ' %' or value LIKE '% '").all.each do |a|
+        a.value = a.value.strip
+        a.save!
+      end
+      DataModel::GeneClaim.where("name LIKE ' %' or name LIKE '% '").all.each do |c|
+        clean_name = c.name.strip
+        clean_claim = DataModel::GeneClaim.where(name: clean_name, nomenclature: c.nomenclature, source_id: c.source_id).first_or_create
+        c.gene_claim_aliases.each do |synonym|
+          DataModel::GeneClaimAlias.where(alias: synonym.alias, nomenclature: synonym.nomenclature, gene_claim_id: clean_claim.id).first_or_create
+          synonym.delete
+        end
+        c.gene_claim_attributes.each do |attribute|
+          DataModel::GeneClaimAttribute.where(name: attribute.name, value: attribute.value, gene_claim_id: clean_claim.if).first_or_create
+          attribute.delete
+        end
+        c.interaction_claims.each do |interaction|
+          clean_interaction = DataModel::InteractionClaim.where(drug_claim_id: interaction.drug_claim_id, gene_claim_id: clean_claim.id, source_id: interaction.source_id).first_or_create
+          interaction.interaction_claim_attributes.each do |attribute|
+            DataModel::InteractionClaimAttribute.where(name: attribute.name, value: attribute.value, interaction_claim_id: clean_interaction.id).first_or_create
+            attribute.delete
+          end
+          interaction.interaction_claim_types.each do |type|
+            clean_interaction.interaction_claim_types << type unless clean_interaction.interaction_claim_types.include? type
+            interaction.interaction_claim_types.delete(type)
+          end
+          interaction.delete
+        end
+        c.delete
+      end
+
+      DataModel::DrugClaimAlias.where("alias LIKE ' %' or alias LIKE '% '").all.each do |a|
+        clean_alias = a.alias.strip
+        DataModel::DrugClaimAlias.where(alias: clean_alias, nomenclature: a.nomenclature, drug_claim_id: a.drug_claim_id).first_or_create
+        a.delete
+      end
+      DataModel::DrugClaimAttribute.where("name LIKE ' %' or name LIKE '% '").all.each do |a|
+        a.name = a.name.strip
+        a.save!
+      end
+      DataModel::DrugClaimAttribute.where("value LIKE ' %' or value LIKE '% '").all.each do |a|
+        a.value = a.value.strip
+        a.save!
+      end
+      DataModel::DrugClaim.where("name LIKE ' %' or name LIKE '% ' or primary_name LIKE ' %' or primary_name LIKE '% '").all.each do |c|
+        clean_name = c.name.strip
+        clean_primary_name = c.primary_name.strip
+        clean_claim = DataModel::DrugClaim.where(name: clean_name, primary_name: clean_primary_name, nomenclature: c.nomenclature, source_id: c.source_id).first_or_create
+        c.drug_claim_aliases.each do |synonym|
+          DataModel::DrugClaimAlias.where(alias: synonym.alias, nomenclature: synonym.nomenclature, drug_claim_id: clean_claim.id).first_or_create
+          synonym.delete
+        end
+        c.drug_claim_attributes.each do |attribute|
+          DataModel::DrugClaimAttribute.where(name: attribute.name, value: attribute.value, drug_claim_id: clean_claim.if).first_or_create
+          attribute.delete
+        end
+        c.interaction_claims.each do |interaction|
+          clean_interaction = DataModel::InteractionClaim.where(gene_claim_id: interaction.gene_claim_id, drug_claim_id: clean_claim.id, source_id: interaction.source_id).first_or_create
+          interaction.interaction_claim_attributes.each do |attribute|
+            DataModel::InteractionClaimAttribute.where(name: attribute.name, value: attribute.value, interaction_claim_id: clean_interaction.id).first_or_create
+            attribute.delete
+          end
+          interaction.interaction_claim_types.each do |type|
+            clean_interaction.interaction_claim_types << type unless clean_interaction.interaction_claim_types.include? type
+            interaction.interaction_claim_types.delete(type)
+          end
+          interaction.delete
+        end
+        c.delete
+      end
+    end
   end
 end

--- a/lib/utils/database.rb
+++ b/lib/utils/database.rb
@@ -246,7 +246,7 @@ module Utils
     end
 
     def self.cleanup_whitespaces
-      DataModel::InteractionClaimType.where("type lIKE ' %' or type LIKE '% '").all.each do |t|
+      DataModel::InteractionClaimType.where("type LIKE ' %' or type LIKE '% '").all.each do |t|
         t.value = t.value.strip
         t.save!
       end

--- a/lib/utils/pmid.rb
+++ b/lib/utils/pmid.rb
@@ -62,11 +62,7 @@ module PMID
     end
 
     def year
-      if Date.new(publication_date.to_i).gregorian?
-        publication_date
-      else
-        Date.parse(publication_date).year
-      end
+      Date.parse(result['sortpubdate']).year
     end
 
     def journal

--- a/lib/utils/pmid.rb
+++ b/lib/utils/pmid.rb
@@ -45,10 +45,6 @@ module PMID
       end
     end
 
-    #def abstract
-    #  xpath_contents_or_nil('//Abstract/AbstractText')
-    #end
-
     def first_author
       if authors.size > 1
         authors.first + " et al."

--- a/lib/utils/pmid.rb
+++ b/lib/utils/pmid.rb
@@ -7,7 +7,7 @@ module PMID
   end
   def self.call_pubmed_api(pubmed_id)
     http_resp = PMID.make_get_request(PMID.url_for_pubmed_id(pubmed_id))
-    PubMedResponse.new(http_resp)
+    PubMedResponse.new(http_resp, pubmed_id.to_s)
   end
   def self.get_citation_from_pubmed_id(pubmed_id)
     resp = PMID.call_pubmed_api(pubmed_id)
@@ -20,13 +20,13 @@ module PMID
 
   private
   def self.url_for_pubmed_id(pubmed_id)
-    "https://www.ncbi.nlm.nih.gov/pubmed/#{pubmed_id}?report=xml&format=text"
+    "https://eutils.ncbi.nlm.nih.gov/entrez/eutils/esummary.fcgi?db=pubmed&id=#{pubmed_id}&retmode=json&tool=DGIdb&email=help@dgidb.org"
   end
 
   class PubMedResponse
-    attr_reader :xml
-    def initialize(response_body)
-      @xml = Nokogiri::XML(Nokogiri::XML(response_body).text)
+    attr_reader :result
+    def initialize(response_body, pmid)
+      @result = JSON.parse(response_body)['result'][pmid]
     end
 
     def citation
@@ -34,75 +34,51 @@ module PMID
     end
 
     def authors
-      xml.xpath('//AuthorList/Author').to_a.each.with_index(1).map do |author, i|
-        {
-          fore_name: author.xpath('ForeName').text,
-          last_name: author.xpath('LastName').text,
-          author_position: i
-        }
-      end
+      result['authors'].map{|a| a['name']}
     end
 
     def pmc_id
-      xpath_contents_or_nil("//PubmedData/ArticleIdList/ArticleId[@IdType='pmc']")
-    end
-
-    def abstract
-      xpath_contents_or_nil('//Abstract/AbstractText')
-    end
-
-    def first_author
-      xpath_contents_or_nil('//AuthorList/Author[1]/LastName') do |author_name|
-        if xml.xpath('//AuthorList/Author').size > 1
-          author_name + " et al."
-        else
-          author_name
+      result['articleids'].each do |articles|
+        if articles['idtype'] == 'pmcid'
+          return articles['value']
         end
       end
     end
 
+    #def abstract
+    #  xpath_contents_or_nil('//Abstract/AbstractText')
+    #end
+
+    def first_author
+      if authors.size > 1
+        authors.first + " et al."
+      else
+        authors.first
+      end
+    end
+
     def publication_date
-     [day, month, year]
+      result['pubdate']
     end
 
     def year
-      xpath_contents_or_nil('//Journal/JournalIssue/PubDate/Year')
-    end
-
-    def month
-      monthname = xpath_contents_or_nil('//Journal/JournalIssue/PubDate/Month')
-      if monthname
-        Date::ABBR_MONTHNAMES.index(monthname)
+      if Date.new(publication_date.to_i).gregorian?
+        publication_date
       else
-        nil
+        Date.parse(publication_date).year
       end
-    end
-
-    def day
-      xpath_contents_or_nil('//Journal/JournalIssue/PubDate/Day')
     end
 
     def journal
-      xpath_contents_or_nil('//Journal/ISOAbbreviation')
+      result['source']
     end
 
     def full_journal_title
-      xpath_contents_or_nil('//Journal/Title')
+      result['fulljournalname']
     end
 
     def article_title
-      xpath_contents_or_nil('//Article/ArticleTitle')
-    end
-
-    private
-    def xpath_contents_or_nil(path)
-      if (node = xml.xpath(path).text).blank?
-        nil
-      elsif block_given?
-        yield node
-      else
-        node
-      end
+      result['title']
     end
   end
 end

--- a/lib/utils/pmid.rb
+++ b/lib/utils/pmid.rb
@@ -43,6 +43,7 @@ module PMID
           return articles['value']
         end
       end
+      return
     end
 
     def first_author


### PR DESCRIPTION
Closes #293.

This also fixes this issue with the PubMed scraping. This PR changes it so that we are using the official API.

