### PR TITLE
Use page_export to download gene category search results

### DIFF
--- a/app/models/gene_category_search_result.rb
+++ b/app/models/gene_category_search_result.rb
@@ -60,4 +60,13 @@ class GeneCategorySearchResult
     end
   end
 
+  def match_type_label
+    if is_ambiguous?
+      "Ambiguous"
+    elsif !has_results?
+      "None"
+    else
+      "Definite"
+    end
+  end
 end

--- a/app/presenters/gene_category_search_results_presenter.rb
+++ b/app/presenters/gene_category_search_results_presenter.rb
@@ -1,5 +1,7 @@
 class GeneCategorySearchResultsPresenter
   include Genome::Extensions
+  attr_reader :search_results
+
   def initialize(search_results, params, start_time, view_context)
     @start_time = start_time
     @search_results = search_results

--- a/app/views/genes/_category_results_table.html.haml
+++ b/app/views/genes/_category_results_table.html.haml
@@ -9,7 +9,7 @@
       %strong
         %em
           =subtitle
-  =render partial: 'shared/table_export', locals: {id: export_id}
+  =render partial: 'shared/page_export'
   %table.table.table-striped.table-bordered{cellpadding: "0", cellspacing: "0", border: "0", id: export_id}
     %thead
       %tr


### PR DESCRIPTION
We were still using the outdated table_export instead of the page_export on this page which, due to the redesigned layout, did not populate the file_contents input.

Closes #321 