### PR TITLE
Add new database columns to source for licensing information

### DIFF
--- a/app/presenters/source_presenter.rb
+++ b/app/presenters/source_presenter.rb
@@ -37,6 +37,18 @@ class SourcePresenter < SimpleDelegator
     end
   end
 
+  def license_linkout
+    if license.present?
+      if license_link.present?
+          @view_context.ext_link_to(license, license_link)
+      else
+          license
+      end
+    else
+      ""
+    end
+  end
+
   private
   def sort_order_to_string(sort_type, source_db_name)
     val = sort_type.sort_value(source_db_name)

--- a/app/views/sources/_category_source.html.haml
+++ b/app/views/sources/_category_source.html.haml
@@ -35,3 +35,8 @@
       %h4
         Full Citation
       %p=source.citation_with_pmid_link.html_safe
+
+    %div(class="item-panel")
+      %h4
+        License
+      %p=source.license_linkout.html_safe

--- a/app/views/sources/_drug_source.html.haml
+++ b/app/views/sources/_drug_source.html.haml
@@ -35,3 +35,8 @@
       %h4
         Full Citation
       %p=source.citation_with_pmid_link.html_safe
+
+    %div(class="item-panel")
+      %h4
+        License
+      %p=source.license_linkout.html_safe

--- a/app/views/sources/_gene_source.html.haml
+++ b/app/views/sources/_gene_source.html.haml
@@ -35,3 +35,8 @@
       %h4
         Full Citation
       %p=source.citation_with_pmid_link.html_safe
+
+    %div(class="item-panel")
+      %h4
+        License
+      %p=source.license_linkout.html_safe

--- a/app/views/sources/_interaction_source.html.haml
+++ b/app/views/sources/_interaction_source.html.haml
@@ -61,3 +61,8 @@
       %h4
         Full Citation
       %p=source.citation_with_pmid_link.html_safe
+
+    %div(class="item-panel")
+      %h4
+        License
+      %p=source.license_linkout.html_safe

--- a/app/views/sources/_source.html.haml
+++ b/app/views/sources/_source.html.haml
@@ -67,4 +67,8 @@
         Full Citation
       %p=source.citation_with_pmid_link.html_safe
 
-
+  %div(class="cell category")
+    %div(class="item-panel")
+      %h4
+        License
+      %p=source.license_linkout.html_safe

--- a/db/migrate/20200608185423_add_license_to_source.rb
+++ b/db/migrate/20200608185423_add_license_to_source.rb
@@ -1,5 +1,5 @@
 class AddLicenseToSource < ActiveRecord::Migration[6.0]
-  def change
+  def up
     add_column :sources, :license, :string
     add_column :sources, :license_link, :string
 
@@ -139,5 +139,10 @@ class AddLicenseToSource < ActiveRecord::Migration[6.0]
     s.license = ''
     s.license_link = ''
     s.save
+  end
+
+  def down
+    remove_column :sources, :license
+    remove_column :sources, :license_link
   end
 end

--- a/db/migrate/20200608185423_add_license_to_source.rb
+++ b/db/migrate/20200608185423_add_license_to_source.rb
@@ -1,0 +1,143 @@
+class AddLicenseToSource < ActiveRecord::Migration[6.0]
+  def change
+    add_column :sources, :license, :string
+    add_column :sources, :license_link, :string
+
+    s = DataModel::Source.find_by(source_db_name: "BaderLabGenes")
+    s.license = ''
+    s.license_link = ''
+    s.save
+    s = DataModel::Source.find_by(source_db_name: "CGI")
+    s.license = 'Creative Commons Attribution-NonCommercial 4.0 (BY-NC)'
+    s.license_link = 'https://www.cancergenomeinterpreter.org/faq#q11c'
+    s.save
+    s = DataModel::Source.find_by(source_db_name: "CIViC")
+    s.license = 'Creative Commons Public Domain Dedication (CC0 1.0 Universal)'
+    s.license_link = 'https://docs.civicdb.org/en/latest/about/faq.html#how-is-civic-licensed'
+    s.save
+    s = DataModel::Source.find_by(source_db_name: "CKB")
+    s.license = 'Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International License'
+    s.license_link = 'https://ckb.jax.org/about/index'
+    s.save
+    s = DataModel::Source.find_by(source_db_name: "CancerCommons")
+    s.license = ''
+    s.license_link = 'https://www.cancercommons.org/terms-of-use/'
+    s.save
+    s = DataModel::Source.find_by(source_db_name: "CarisMolecularIntelligence")
+    s.license = ''
+    s.license_link = ''
+    s.save
+    s = DataModel::Source.find_by(source_db_name: "ChemblDrugs")
+    s.license = 'Creative Commons Attribution-Share Alike 3.0 Unported License'
+    s.license_link = 'https://chembl.gitbook.io/chembl-interface-documentation/about'
+    s.save
+    s = DataModel::Source.find_by(source_db_name: "ChemblInteractions")
+    s.license = 'Creative Commons Attribution-Share Alike 3.0 Unported License'
+    s.license_link = 'https://chembl.gitbook.io/chembl-interface-documentation/about'
+    s.save
+    s = DataModel::Source.find_by(source_db_name: "ClearityFoundationBiomarkers")
+    s.license = ''
+    s.license_link = ''
+    s.save
+    s = DataModel::Source.find_by(source_db_name: "ClearityFoundationClinicalTrial")
+    s.license = ''
+    s.license_link = ''
+    s.save
+    s = DataModel::Source.find_by(source_db_name: "DoCM")
+    s.license = 'Creative Commons Attribution 4.0 International License'
+    s.license_link = 'http://www.docm.info/about'
+    s.save
+    s = DataModel::Source.find_by(source_db_name: "DrugBank")
+    s.license = ''
+    s.license_link = 'https://dev.drugbankplus.com/guides/drugbank/citing?_ga=2.29505343.1251048939.1591976592-781844916.1591645816'
+    s.save
+    s = DataModel::Source.find_by(source_db_name: "Ensembl")
+    s.license = ''
+    s.license_link = 'https://useast.ensembl.org/info/about/legal/disclaimer.html'
+    s.save
+    s = DataModel::Source.find_by(source_db_name: "Entrez")
+    s.license = ''
+    s.license_link = ''
+    s.save
+    s = DataModel::Source.find_by(source_db_name: "FDA")
+    s.license = ''
+    s.license_link = ''
+    s.save
+    s = DataModel::Source.find_by(source_db_name: "FoundationOneGenes")
+    s.license = ''
+    s.license_link = ''
+    s.save
+    s = DataModel::Source.find_by(source_db_name: "GO")
+    s.license = 'Creative Commons Attribution 4.0 Unported License'
+    s.license_link = 'http://geneontology.org/docs/go-citation-policy/'
+    s.save
+    s = DataModel::Source.find_by(source_db_name: "GuideToPharmacologyGenes")
+    s.license = 'Creative Commons Attribution-ShareAlike 4.0 International License'
+    s.license_link = 'https://www.guidetopharmacology.org/about.jsp'
+    s.save
+    s = DataModel::Source.find_by(source_db_name: "GuideToPharmacologyInteractions")
+    s.license = 'Creative Commons Attribution-ShareAlike 4.0 International License'
+    s.license_link = 'https://www.guidetopharmacology.org/about.jsp'
+    s.save
+    s = DataModel::Source.find_by(source_db_name: "HingoraniCasas")
+    s.license = ''
+    s.license_link = ''
+    s.save
+    s = DataModel::Source.find_by(source_db_name: "HopkinsGroom")
+    s.license = ''
+    s.license_link = ''
+    s.save
+    s = DataModel::Source.find_by(source_db_name: "MskImpact")
+    s.license = ''
+    s.license_link = ''
+    s.save
+    s = DataModel::Source.find_by(source_db_name: "MyCancerGenome")
+    s.license = ''
+    s.license_link = 'https://www.mycancergenome.org/content/page/legal-policies-licensing/'
+    s.save
+    s = DataModel::Source.find_by(source_db_name: "MyCancerGenomeClinicalTrial")
+    s.license = ''
+    s.license_link = 'https://www.mycancergenome.org/content/page/legal-policies-licensing/'
+    s.save
+    s = DataModel::Source.find_by(source_db_name: "NCI")
+    s.license = ''
+    s.license_link = ''
+    s.save
+    s = DataModel::Source.find_by(source_db_name: "OncoKB")
+    s.license = ''
+    s.license_link = 'https://www.oncokb.org/terms'
+    s.save
+    s = DataModel::Source.find_by(source_db_name: "PharmGKB")
+    s.license = 'Creative Commons Attribution-ShareAlike 4.0 International License'
+    s.license_link = 'https://www.pharmgkb.org/page/faqs'
+    s.save
+    s = DataModel::Source.find_by(source_db_name: "PubChem")
+    s.license = ''
+    s.license_link = 'https://pubchemdocs.ncbi.nlm.nih.gov/downloads'
+    s.save
+    s = DataModel::Source.find_by(source_db_name: "RussLampel")
+    s.license = ''
+    s.license_link = ''
+    s.save
+    s = DataModel::Source.find_by(source_db_name: "TALC")
+    s.license = ''
+    s.license_link = ''
+    s.save
+    s = DataModel::Source.find_by(source_db_name: "TEND")
+    s.license = ''
+    s.license_link = ''
+    s.save
+    s = DataModel::Source.find_by(source_db_name: "TTD")
+    s.license = ''
+    s.license_link = ''
+    s.save
+    s = DataModel::Source.find_by(source_db_name: "TdgClinicalTrial")
+    s.license = ''
+    s.license_link = ''
+    s.save
+    s = DataModel::Source.find_by(source_db_name: "dGene")
+    s.license = ''
+    s.license_link = ''
+    s.save
+  end
+end

--- a/db/migrate/20200608185423_add_license_to_source.rb
+++ b/db/migrate/20200608185423_add_license_to_source.rb
@@ -4,8 +4,8 @@ class AddLicenseToSource < ActiveRecord::Migration[6.0]
     add_column :sources, :license_link, :string
 
     s = DataModel::Source.find_by(source_db_name: "BaderLabGenes")
-    s.license = ''
-    s.license_link = ''
+    s.license = 'Supplemental data from CC-BY 3.0 arXiv preprint'
+    s.license_link = 'http://baderlab.org/Data/RoadsNotTaken'
     s.save
     s = DataModel::Source.find_by(source_db_name: "CGI")
     s.license = 'Creative Commons Attribution-NonCommercial 4.0 (BY-NC)'
@@ -20,12 +20,12 @@ class AddLicenseToSource < ActiveRecord::Migration[6.0]
     s.license_link = 'https://ckb.jax.org/about/index'
     s.save
     s = DataModel::Source.find_by(source_db_name: "CancerCommons")
-    s.license = ''
+    s.license = 'Custom non-commercial'
     s.license_link = 'https://www.cancercommons.org/terms-of-use/'
     s.save
     s = DataModel::Source.find_by(source_db_name: "CarisMolecularIntelligence")
-    s.license = ''
-    s.license_link = ''
+    s.license = 'Unknown; data is no longer publicly available from site'
+    s.license_link = 'https://www.carismolecularintelligence.com/contact-us/'
     s.save
     s = DataModel::Source.find_by(source_db_name: "ChemblDrugs")
     s.license = 'Creative Commons Attribution-Share Alike 3.0 Unported License'
@@ -36,36 +36,36 @@ class AddLicenseToSource < ActiveRecord::Migration[6.0]
     s.license_link = 'https://chembl.gitbook.io/chembl-interface-documentation/about'
     s.save
     s = DataModel::Source.find_by(source_db_name: "ClearityFoundationBiomarkers")
-    s.license = ''
-    s.license_link = ''
+    s.license = 'Unknown; data is no longer publicly available from site'
+    s.license_link = 'https://www.clearityfoundation.org/about-clearity/contact/'
     s.save
     s = DataModel::Source.find_by(source_db_name: "ClearityFoundationClinicalTrial")
-    s.license = ''
-    s.license_link = ''
+    s.license = 'Unknown; data is no longer publicly available from site'
+    s.license_link = 'https://www.clearityfoundation.org/about-clearity/contact/'
     s.save
     s = DataModel::Source.find_by(source_db_name: "DoCM")
     s.license = 'Creative Commons Attribution 4.0 International License'
     s.license_link = 'http://www.docm.info/about'
     s.save
     s = DataModel::Source.find_by(source_db_name: "DrugBank")
-    s.license = ''
+    s.license = 'Custom non-commercial'
     s.license_link = 'https://dev.drugbankplus.com/guides/drugbank/citing?_ga=2.29505343.1251048939.1591976592-781844916.1591645816'
     s.save
     s = DataModel::Source.find_by(source_db_name: "Ensembl")
-    s.license = ''
+    s.license = 'Unrestricted license, pass-through constraints'
     s.license_link = 'https://useast.ensembl.org/info/about/legal/disclaimer.html'
     s.save
     s = DataModel::Source.find_by(source_db_name: "Entrez")
-    s.license = ''
-    s.license_link = ''
+    s.license = 'Unrestricted license, pass-through constraints'
+    s.license_link = 'https://www.nlm.nih.gov/accessibility.html'
     s.save
     s = DataModel::Source.find_by(source_db_name: "FDA")
-    s.license = ''
-    s.license_link = ''
+    s.license = 'Public Domain'
+    s.license_link = 'https://www.fda.gov/about-fda/about-website/website-policies#linking'
     s.save
     s = DataModel::Source.find_by(source_db_name: "FoundationOneGenes")
-    s.license = ''
-    s.license_link = ''
+    s.license = 'Unknown; data is no longer publicly available from site'
+    s.license_link = 'https://www.foundationmedicine.com/resource/legal-and-privacy'
     s.save
     s = DataModel::Source.find_by(source_db_name: "GO")
     s.license = 'Creative Commons Attribution 4.0 Unported License'
@@ -80,31 +80,31 @@ class AddLicenseToSource < ActiveRecord::Migration[6.0]
     s.license_link = 'https://www.guidetopharmacology.org/about.jsp'
     s.save
     s = DataModel::Source.find_by(source_db_name: "HingoraniCasas")
-    s.license = ''
-    s.license_link = ''
+    s.license = 'Supplementary data from Author Copyright publication'
+    s.license_link = 'https://stm.sciencemag.org/content/9/383/eaag1166/tab-pdf'
     s.save
     s = DataModel::Source.find_by(source_db_name: "HopkinsGroom")
-    s.license = ''
-    s.license_link = ''
+    s.license = 'Supplementary data from Nature Publishing Group copyright publication'
+    s.license_link = 'https://www.nature.com/articles/nrd892'
     s.save
     s = DataModel::Source.find_by(source_db_name: "MskImpact")
-    s.license = ''
-    s.license_link = ''
+    s.license = 'Supplementary data from American Society for Investigative Pathology and the Association for Molecular Pathology copyright publication'
+    s.license_link = 'https://jmd.amjpathol.org/action/showPdf?pii=S1525-1578%2815%2900045-8'
     s.save
     s = DataModel::Source.find_by(source_db_name: "MyCancerGenome")
-    s.license = ''
+    s.license = 'Restrictive, custom, non-commercial'
     s.license_link = 'https://www.mycancergenome.org/content/page/legal-policies-licensing/'
     s.save
     s = DataModel::Source.find_by(source_db_name: "MyCancerGenomeClinicalTrial")
-    s.license = ''
+    s.license = 'Restrictive, custom, non-commercial'
     s.license_link = 'https://www.mycancergenome.org/content/page/legal-policies-licensing/'
     s.save
     s = DataModel::Source.find_by(source_db_name: "NCI")
-    s.license = ''
-    s.license_link = ''
+    s.license = 'Public domain'
+    s.license_link = 'https://www.cancer.gov/policies/copyright-reuse'
     s.save
     s = DataModel::Source.find_by(source_db_name: "OncoKB")
-    s.license = ''
+    s.license = 'Restrictive, non-commercial'
     s.license_link = 'https://www.oncokb.org/terms'
     s.save
     s = DataModel::Source.find_by(source_db_name: "PharmGKB")
@@ -112,32 +112,32 @@ class AddLicenseToSource < ActiveRecord::Migration[6.0]
     s.license_link = 'https://www.pharmgkb.org/page/faqs'
     s.save
     s = DataModel::Source.find_by(source_db_name: "PubChem")
-    s.license = ''
+    s.license = 'Public domain'
     s.license_link = 'https://pubchemdocs.ncbi.nlm.nih.gov/downloads'
     s.save
     s = DataModel::Source.find_by(source_db_name: "RussLampel")
-    s.license = ''
-    s.license_link = ''
+    s.license = 'Unknown; data is no longer publicly available from external site, referenced in Elsevier copyright publication'
+    s.license_link = 'https://www.sciencedirect.com/science/article/pii/S1359644605036664'
     s.save
     s = DataModel::Source.find_by(source_db_name: "TALC")
-    s.license = ''
-    s.license_link = ''
+    s.license = 'Data extracted from tables in Elsevier copyright publication'
+    s.license_link = 'https://www.sciencedirect.com/science/article/pii/S1525730413002350'
     s.save
     s = DataModel::Source.find_by(source_db_name: "TEND")
-    s.license = ''
-    s.license_link = ''
+    s.license = 'Supplementary table from Macmillan Publishers Limited copyright publication'
+    s.license_link = 'https://www.nature.com/articles/nrd3478'
     s.save
     s = DataModel::Source.find_by(source_db_name: "TTD")
-    s.license = ''
-    s.license_link = ''
+    s.license = 'Unclear. Website states "All Rights Reserved" but resource structure and description in 2002 publication indicate "open-access".'
+    s.license_link = 'https://academic.oup.com/nar/article/30/1/412/1331814'
     s.save
     s = DataModel::Source.find_by(source_db_name: "TdgClinicalTrial")
-    s.license = ''
-    s.license_link = ''
+    s.license = 'Supplementary table from Annual Reviews copyright publication'
+    s.license_link = 'https://www.annualreviews.org/doi/10.1146/annurev-pharmtox-011613-135943?url_ver=Z39.88-2003&rfr_id=ori%3Arid%3Acrossref.org&rfr_dat=cr_pub++0pubmed'
     s.save
     s = DataModel::Source.find_by(source_db_name: "dGene")
-    s.license = ''
-    s.license_link = ''
+    s.license = 'Creative Commons Attribution License (Version not specified)'
+    s.license_link = 'https://journals.plos.org/plosone/article?id=10.1371/journal.pone.0067980#pone.0067980.s002'
     s.save
   end
 

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -654,7 +654,9 @@ CREATE TABLE public.sources (
     gene_claims_in_groups_count integer DEFAULT 0,
     drug_claims_in_groups_count integer DEFAULT 0,
     source_trust_level_id character varying(255),
-    gene_gene_interaction_claims_count integer DEFAULT 0
+    gene_gene_interaction_claims_count integer DEFAULT 0,
+    license character varying,
+    license_link character varying
 );
 
 
@@ -2054,6 +2056,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20170914145053'),
 ('20191016180948'),
 ('20191107152512'),
+('20200608185423'),
 ('20200615173440');
 
 

--- a/lib/genome/importers/bader_lab/bader_lab_tsv_importer.rb
+++ b/lib/genome/importers/bader_lab/bader_lab_tsv_importer.rb
@@ -12,6 +12,8 @@ module Genome
           source_trust_level_id: DataModel::SourceTrustLevel.EXPERT_CURATED,
           source_db_name: 'BaderLabGenes',
           full_name: 'Bader Lab Genes',
+          license: 'Supplemental data from CC-BY 3.0 arXiv preprint',
+          license_link: 'http://baderlab.org/Data/RoadsNotTaken',
         }
       end
 

--- a/lib/genome/importers/cancer_commons/cancer_commons_tsv_importer.rb
+++ b/lib/genome/importers/cancer_commons/cancer_commons_tsv_importer.rb
@@ -12,6 +12,8 @@ module Genome
           source_trust_level_id: DataModel::SourceTrustLevel.EXPERT_CURATED,
           source_db_name: 'CancerCommons',
           full_name: 'Cancer Commons',
+          license: 'Custom non-commercial',
+          license_link: 'https://www.cancercommons.org/terms-of-use/',
         }
       end
 

--- a/lib/genome/importers/caris_molecular_intelligence/caris_molecular_intelligence_tsv_importer.rb
+++ b/lib/genome/importers/caris_molecular_intelligence/caris_molecular_intelligence_tsv_importer.rb
@@ -11,7 +11,8 @@ module Genome
           source_type_id: DataModel::SourceType.POTENTIALLY_DRUGGABLE,
           source_db_name: 'CarisMolecularIntelligence',
           full_name: 'Caris Molecular Intelligence',
-          source_trust_level_id: DataModel::SourceTrustLevel.EXPERT_CURATED
+          source_trust_level_id: DataModel::SourceTrustLevel.EXPERT_CURATED,
+
         }
       end
       

--- a/lib/genome/importers/caris_molecular_intelligence/caris_molecular_intelligence_tsv_importer.rb
+++ b/lib/genome/importers/caris_molecular_intelligence/caris_molecular_intelligence_tsv_importer.rb
@@ -12,7 +12,8 @@ module Genome
           source_db_name: 'CarisMolecularIntelligence',
           full_name: 'Caris Molecular Intelligence',
           source_trust_level_id: DataModel::SourceTrustLevel.EXPERT_CURATED,
-
+          license: 'Unknown; data is no longer publicly available from site',
+          license_link: 'https://www.carismolecularintelligence.com/contact-us/',
         }
       end
       

--- a/lib/genome/importers/cgi/new_cgi.rb
+++ b/lib/genome/importers/cgi/new_cgi.rb
@@ -33,7 +33,9 @@ module Genome; module Importers; module Cgi;
               source_db_version:  get_version,
               source_type_id: DataModel::SourceType.INTERACTION,
               source_db_name: 'CGI',
-              full_name: 'Cancer Genome Interpreter'
+              full_name: 'Cancer Genome Interpreter',
+              license: 'Creative Commons Attribution-NonCommercial 4.0 (BY-NC)',
+              license_url: 'https://www.cancergenomeinterpreter.org/faq#q11c',
           }
       )
     end

--- a/lib/genome/importers/chembl/chembl_tsv_importer.rb
+++ b/lib/genome/importers/chembl/chembl_tsv_importer.rb
@@ -11,7 +11,9 @@ module Genome
           source_type_id: DataModel::SourceType.INTERACTION,
           source_db_name: 'ChEMBL',
           full_name: 'The ChEMBL Bioactivity Database',
-          source_trust_level_id: DataModel::SourceTrustLevel.EXPERT_CURATED
+          source_trust_level_id: DataModel::SourceTrustLevel.EXPERT_CURATED,
+          license: 'Creative Commons Attribution-Share Alike 3.0 Unported License',
+          license_link: 'https://chembl.gitbook.io/chembl-interface-documentation/about',
         }
       end
 

--- a/lib/genome/importers/clearity_foundation_biomarker/clearity_foundation_biomarker_tsv_importer.rb
+++ b/lib/genome/importers/clearity_foundation_biomarker/clearity_foundation_biomarker_tsv_importer.rb
@@ -12,6 +12,8 @@ module Genome
           source_trust_level_id: DataModel::SourceTrustLevel.EXPERT_CURATED,
           source_db_name: 'ClearityFoundationBiomarkers',
           full_name: 'Clearity Foundation Biomarkers',
+          license: 'Unknown; data is no longer publicly available from site',
+          license_link: 'https://www.clearityfoundation.org/about-clearity/contact/',
         }
       end
 

--- a/lib/genome/importers/clearity_foundation_clinical_trial/clearity_foundation_clinical_trial_tsv_importer.rb
+++ b/lib/genome/importers/clearity_foundation_clinical_trial/clearity_foundation_clinical_trial_tsv_importer.rb
@@ -12,6 +12,8 @@
               source_trust_level_id: DataModel::SourceTrustLevel.EXPERT_CURATED,
               source_db_name: 'ClearityFoundationClinicalTrial',
               full_name: 'Clearity Foundation Clinical Trial',
+              license: 'Unknown; data is no longer publicly available from site',
+              license_link: 'https://www.clearityfoundation.org/about-clearity/contact/',
           }
         end
 

--- a/lib/genome/importers/d_gene/d_gene_tsv_importer.rb
+++ b/lib/genome/importers/d_gene/d_gene_tsv_importer.rb
@@ -10,7 +10,9 @@ module Genome
           source_db_version:  '27-Jun-2013',
           source_type_id:     DataModel::SourceType.POTENTIALLY_DRUGGABLE,
           source_db_name:     'dGene',
-          full_name:          'dGENE - The Druggable Gene List'
+          full_name:          'dGENE - The Druggable Gene List',
+          license: 'Creative Commons Attribution License (Version not specified)',
+          license_link: 'https://journals.plos.org/plosone/article?id=10.1371/journal.pone.0067980#pone.0067980.s002',
         }
       end
 

--- a/lib/genome/importers/drug_bank/drug_bank_tsv_importer.rb
+++ b/lib/genome/importers/drug_bank/drug_bank_tsv_importer.rb
@@ -21,7 +21,9 @@ module Genome
           source_type_id: DataModel::SourceType.INTERACTION,
           source_db_name: 'DrugBank',
           full_name: 'DrugBank - Open Data Drug & Drug Target Database',
-          source_trust_level_id: DataModel::SourceTrustLevel.EXPERT_CURATED
+          source_trust_level_id: DataModel::SourceTrustLevel.EXPERT_CURATED,
+          license: '',
+          license_url: 'https://dev.drugbankplus.com/guides/drugbank/citing?_ga=2.29505343.1251048939.1591976592-781844916.1591645816',
         }
       end
 

--- a/lib/genome/importers/drug_bank/new_drug_bank.rb
+++ b/lib/genome/importers/drug_bank/new_drug_bank.rb
@@ -40,7 +40,8 @@ module Genome; module Importers; module DrugBank;
         source_type_id: DataModel::SourceType.INTERACTION,
         source_db_name: 'DrugBank',
         full_name: 'DrugBank - Open Data Drug & Drug Target Database',
-        license: '',
+        license: 'Custom non-commercial',
+        license_link: 'https://dev.drugbankplus.com/guides/drugbank/citing?_ga=2.29505343.1251048939.1591976592-781844916.1591645816',
         #source_trust_level_id: DataModel::SourceTrustLevel.EXPERT_CURATED
       ).first_or_create
     end

--- a/lib/genome/importers/drug_bank/new_drug_bank.rb
+++ b/lib/genome/importers/drug_bank/new_drug_bank.rb
@@ -39,7 +39,8 @@ module Genome; module Importers; module DrugBank;
         source_db_version: get_version,
         source_type_id: DataModel::SourceType.INTERACTION,
         source_db_name: 'DrugBank',
-        full_name: 'DrugBank - Open Data Drug & Drug Target Database'
+        full_name: 'DrugBank - Open Data Drug & Drug Target Database',
+        license: '',
         #source_trust_level_id: DataModel::SourceTrustLevel.EXPERT_CURATED
       ).first_or_create
     end

--- a/lib/genome/importers/ensembl/new_ensembl.rb
+++ b/lib/genome/importers/ensembl/new_ensembl.rb
@@ -27,7 +27,9 @@ module Genome; module Importers; module Ensembl;
         source_db_version:  version,
         source_type_id:     DataModel::SourceType.GENE,
         source_db_name:     'Ensembl',
-        full_name:          'Ensembl'
+        full_name:          'Ensembl',
+        license:            '',
+        license_url:        'https://useast.ensembl.org/info/about/legal/disclaimer.html',
       ).first_or_create
     end
 

--- a/lib/genome/importers/ensembl/new_ensembl.rb
+++ b/lib/genome/importers/ensembl/new_ensembl.rb
@@ -28,7 +28,7 @@ module Genome; module Importers; module Ensembl;
         source_type_id:     DataModel::SourceType.GENE,
         source_db_name:     'Ensembl',
         full_name:          'Ensembl',
-        license:            '',
+        license: 'Unrestricted license, pass-through constraints',
         license_url:        'https://useast.ensembl.org/info/about/legal/disclaimer.html',
       ).first_or_create
     end

--- a/lib/genome/importers/entrez/new_entrez.rb
+++ b/lib/genome/importers/entrez/new_entrez.rb
@@ -21,7 +21,8 @@ module Genome; module Importers; module Entrez;
         source_type_id: DataModel::SourceType.GENE,
         source_db_name: 'Entrez',
         full_name: 'NCBI Entrez Gene',
-        license: '',
+        license: 'Unrestricted license, pass-through constraints',
+        license_link: 'https://www.nlm.nih.gov/accessibility.html',
       ).first_or_initialize
       source.source_db_version = Date.today.strftime("%d-%B-%Y")
       source.save

--- a/lib/genome/importers/entrez/new_entrez.rb
+++ b/lib/genome/importers/entrez/new_entrez.rb
@@ -20,7 +20,8 @@ module Genome; module Importers; module Entrez;
         citation: 'Entrez Gene: gene-centered information at NCBI. Maglott D, Ostell J, Pruitt KD, Tatusova T. Nucleic Acids Res. 2011 Jan;39(Database issue)52-7. Epub 2010 Nov 28. PMID: 21115458.',
         source_type_id: DataModel::SourceType.GENE,
         source_db_name: 'Entrez',
-        full_name: 'NCBI Entrez Gene'
+        full_name: 'NCBI Entrez Gene',
+        license: '',
       ).first_or_initialize
       source.source_db_version = Date.today.strftime("%d-%B-%Y")
       source.save

--- a/lib/genome/importers/fda/fda.rb
+++ b/lib/genome/importers/fda/fda.rb
@@ -33,7 +33,8 @@ class NewFda < Genome::OnlineUpdater
             source_type_id: DataModel::SourceType.INTERACTION,
             source_db_name: 'FDA',
             full_name: 'FDA Pharmacogenomic Biomarkers',
-            license: '',
+            license: 'Public Domain',
+            license_link: 'https://www.fda.gov/about-fda/about-website/website-policies#linking',
         }
     )
   end

--- a/lib/genome/importers/fda/fda.rb
+++ b/lib/genome/importers/fda/fda.rb
@@ -32,7 +32,8 @@ class NewFda < Genome::OnlineUpdater
             source_db_version:  get_version,
             source_type_id: DataModel::SourceType.INTERACTION,
             source_db_name: 'FDA',
-            full_name: 'FDA Pharmacogenomic Biomarkers'
+            full_name: 'FDA Pharmacogenomic Biomarkers',
+            license: '',
         }
     )
   end

--- a/lib/genome/importers/foundation_one_interactions/foundation_one_interactions_tsv_importer.rb
+++ b/lib/genome/importers/foundation_one_interactions/foundation_one_interactions_tsv_importer.rb
@@ -12,6 +12,8 @@ module Genome
           source_trust_level_id: DataModel::SourceTrustLevel.EXPERT_CURATED,
           source_db_name: 'Foundation One',
           full_name: 'Foundation One',
+          license: 'Unknown; data is no longer publicly available from site',
+          license_link: 'https://www.foundationmedicine.com/resource/legal-and-privacy',
         }
       end
 

--- a/lib/genome/importers/guide_to_pharmacology_interactions/new_guide_to_pharmacology.rb
+++ b/lib/genome/importers/guide_to_pharmacology_interactions/new_guide_to_pharmacology.rb
@@ -106,6 +106,8 @@ of drug targets and their ligands." Nucleic acids research 42.D1 (2014): D1098-D
           source_type_id: DataModel::SourceType.INTERACTION,
           source_db_name: 'GuideToPharmacologyInteractions',
           full_name: 'Guide to Pharmacology Interactions',
+          license: 'Creative Commons Attribution-ShareAlike 4.0 International License',
+          license_url: 'https://www.guidetopharmacology.org/about.jsp',
       ).first_or_initialize
       source.source_db_version = Date.today.strftime("%d-%B-%Y")
       source.save

--- a/lib/genome/importers/hingorani_casas/hingorani_casas_tsv_importer.rb
+++ b/lib/genome/importers/hingorani_casas/hingorani_casas_tsv_importer.rb
@@ -10,7 +10,9 @@ module Genome
           source_type_id:     DataModel::SourceType.POTENTIALLY_DRUGGABLE,
           source_trust_level_id: DataModel::SourceTrustLevel.EXPERT_CURATED,
           source_db_name:     'HingoraniCasas',
-          full_name:          'The druggable genome and support for target identification and validation in drug development (Hingorani & Casas, 2017)'
+          full_name:          'The druggable genome and support for target identification and validation in drug development (Hingorani & Casas, 2017)',
+          license: 'Supplementary data from Author Copyright publication',
+          license_link: 'https://stm.sciencemag.org/content/9/383/eaag1166/tab-pdf',
         }
       end
 

--- a/lib/genome/importers/hopkins_groom/hopkins_groom_tsv_importer.rb
+++ b/lib/genome/importers/hopkins_groom/hopkins_groom_tsv_importer.rb
@@ -9,7 +9,9 @@ module Genome
           source_db_version:  '11-Sep-2012',
           source_type_id:     DataModel::SourceType.POTENTIALLY_DRUGGABLE,
           source_db_name:     'HopkinsGroom',
-          full_name:          'The druggable genome (Hopkins & Groom, 2002)'
+          full_name:          'The druggable genome (Hopkins & Groom, 2002)',
+          licensei: 'Supplementary data from Nature Publishing Group copyright publication',
+          license_link: 'https://www.nature.com/articles/nrd892',
         }
       end
 

--- a/lib/genome/importers/msk_impact/msk_impact_tsv_importer.rb
+++ b/lib/genome/importers/msk_impact/msk_impact_tsv_importer.rb
@@ -11,7 +11,9 @@ module Genome
             source_type_id: DataModel::SourceType.POTENTIALLY_DRUGGABLE,
             source_db_name: 'MskImpact',
             full_name: 'Memorial Sloan Kettering IMPACT',
-            source_trust_level_id: DataModel::SourceTrustLevel.EXPERT_CURATED
+            source_trust_level_id: DataModel::SourceTrustLevel.EXPERT_CURATED,
+            license: 'Supplementary data from American Society for Investigative Pathology and the Association for Molecular Pathology copyright publication',
+            license_link: 'https://jmd.amjpathol.org/action/showPdf?pii=S1525-1578%2815%2900045-8',
         }
       end
 

--- a/lib/genome/importers/my_cancer_genome/my_cancer_genome_tsv_importer.rb
+++ b/lib/genome/importers/my_cancer_genome/my_cancer_genome_tsv_importer.rb
@@ -12,6 +12,8 @@ module Genome
           source_db_name: 'MyCancerGenome',
           full_name: 'My Cancer Genome',
           source_trust_level_id: DataModel::SourceTrustLevel.EXPERT_CURATED,
+          license: '',
+          license_url: 'https://www.mycancergenome.org/content/page/legal-policies-licensing/',
         }
       end
 

--- a/lib/genome/importers/my_cancer_genome/my_cancer_genome_tsv_importer.rb
+++ b/lib/genome/importers/my_cancer_genome/my_cancer_genome_tsv_importer.rb
@@ -12,7 +12,7 @@ module Genome
           source_db_name: 'MyCancerGenome',
           full_name: 'My Cancer Genome',
           source_trust_level_id: DataModel::SourceTrustLevel.EXPERT_CURATED,
-          license: '',
+          license: 'Restrictive, custom, non-commercial',
           license_url: 'https://www.mycancergenome.org/content/page/legal-policies-licensing/',
         }
       end

--- a/lib/genome/importers/my_cancer_genome_clinical_trial/my_cancer_genome_clinical_trial_tsv_importer.rb
+++ b/lib/genome/importers/my_cancer_genome_clinical_trial/my_cancer_genome_clinical_trial_tsv_importer.rb
@@ -11,6 +11,8 @@
               source_trust_level_id: DataModel::SourceTrustLevel.EXPERT_CURATED,
               source_db_name: 'MyCancerGenomeClinicalTrial',
               full_name: 'MyCancerGenome Clinical Trial',
+              license: '',
+              license_url: 'https://www.mycancergenome.org/content/page/legal-policies-licensing/',
           }
         end
 

--- a/lib/genome/importers/my_cancer_genome_clinical_trial/my_cancer_genome_clinical_trial_tsv_importer.rb
+++ b/lib/genome/importers/my_cancer_genome_clinical_trial/my_cancer_genome_clinical_trial_tsv_importer.rb
@@ -11,7 +11,7 @@
               source_trust_level_id: DataModel::SourceTrustLevel.EXPERT_CURATED,
               source_db_name: 'MyCancerGenomeClinicalTrial',
               full_name: 'MyCancerGenome Clinical Trial',
-              license: '',
+              license: 'Restrictive, custom, non-commercial',
               license_url: 'https://www.mycancergenome.org/content/page/legal-policies-licensing/',
           }
         end

--- a/lib/genome/importers/nci/nci.rb
+++ b/lib/genome/importers/nci/nci.rb
@@ -33,7 +33,8 @@ module Genome; module Importers; module Nci;
               source_type_id: DataModel::SourceType.INTERACTION,
               source_db_name: 'NCI',
               full_name: 'NCI Cancer Gene Index',
-              license: ''
+              license: 'Public domain',
+              license_link: 'https://www.cancer.gov/policies/copyright-reuse',
           }
       )
     end

--- a/lib/genome/importers/nci/nci.rb
+++ b/lib/genome/importers/nci/nci.rb
@@ -32,7 +32,8 @@ module Genome; module Importers; module Nci;
               source_db_version:  get_version,
               source_type_id: DataModel::SourceType.INTERACTION,
               source_db_name: 'NCI',
-              full_name: 'NCI Cancer Gene Index'
+              full_name: 'NCI Cancer Gene Index',
+              license: ''
           }
       )
     end

--- a/lib/genome/importers/pharmgkb/pharmgkb_tsv_importer.rb
+++ b/lib/genome/importers/pharmgkb/pharmgkb_tsv_importer.rb
@@ -9,7 +9,9 @@ module Genome
           source_db_version:  '12-Jul-2012',
           source_type_id:    DataModel::SourceType.INTERACTION,
           source_db_name:    'PharmGKB',
-          full_name:         'PharmGKB - The Pharmacogenomics Knowledgebase'
+          full_name:         'PharmGKB - The Pharmacogenomics Knowledgebase',
+          license:           'Creative Commons Attribution-ShareAlike 4.0 International License',
+          license_url:       'https://www.pharmgkb.org/page/faqs',
         }
       end
 

--- a/lib/genome/importers/russ_lampel/russ_lampel_tsv_importer.rb
+++ b/lib/genome/importers/russ_lampel/russ_lampel_tsv_importer.rb
@@ -9,8 +9,9 @@ module Genome
           source_db_version:  '26-Jul-2011',
           source_type_id:     DataModel::SourceType.GENE,
           source_db_name:     'RussLampel',
-          full_name:          'The druggable genome: an update (Russ & Lampel, 2005)'
-
+          full_name:          'The druggable genome: an update (Russ & Lampel, 2005)',
+          license: 'Unknown; data is no longer publicly available from external site, referenced in Elsevier copyright publication',
+          license_link: 'https://www.sciencedirect.com/science/article/pii/S1359644605036664',
         }
       end
 

--- a/lib/genome/importers/talc/talc_tsv_importer.rb
+++ b/lib/genome/importers/talc/talc_tsv_importer.rb
@@ -10,7 +10,9 @@ module Genome
             source_type_id: DataModel::SourceType.INTERACTION,
             source_trust_level_id:  DataModel::SourceTrustLevel.EXPERT_CURATED,
             source_db_name: 'TALC',
-            full_name: 'Targeted Agents in Lung Cancer (Commentary, 2014)'
+            full_name: 'Targeted Agents in Lung Cancer (Commentary, 2014)',
+            license: 'Data extracted from tables in Elsevier copyright publication',
+            license_link: 'https://www.sciencedirect.com/science/article/pii/S1525730413002350',
         }
       end
 

--- a/lib/genome/importers/tdg_clinical_trial/tdg_clinical_trial_tsv_importer.rb
+++ b/lib/genome/importers/tdg_clinical_trial/tdg_clinical_trial_tsv_importer.rb
@@ -10,7 +10,9 @@ module Genome
           source_db_version:  'Jan-2014',
           source_type_id:    DataModel::SourceType.INTERACTION,
           source_db_name:    'TdgClinicalTrial',
-          full_name:         'The Druggable Genome: Evaluation of Drug Targets in Clinical Trials Suggests Major Shifts in Molecular Class and Indication (Rask-Andersen, Masuram, Schioth 2014)'
+          full_name:         'The Druggable Genome: Evaluation of Drug Targets in Clinical Trials Suggests Major Shifts in Molecular Class and Indication (Rask-Andersen, Masuram, Schioth 2014)',
+          license: 'Supplementary table from Annual Reviews copyright publication',
+          license_link: 'https://www.annualreviews.org/doi/10.1146/annurev-pharmtox-011613-135943?url_ver=Z39.88-2003&rfr_id=ori%3Arid%3Acrossref.org&rfr_dat=cr_pub++0pubmed',
         }
       end
 

--- a/lib/genome/importers/tend/tend_tsv_importer.rb
+++ b/lib/genome/importers/tend/tend_tsv_importer.rb
@@ -9,7 +9,9 @@ module Genome
           source_db_version:  '01-Aug-2011',
           source_type_id:    DataModel::SourceType.INTERACTION,
           source_db_name:    'TEND',
-          full_name:         'Trends in the exploitation of novel drug targets (Rask-Andersen, et al., 2011)'
+          full_name:         'Trends in the exploitation of novel drug targets (Rask-Andersen, et al., 2011)',
+          license: 'Supplementary table from Macmillan Publishers Limited copyright publication',
+          license_link: 'https://www.nature.com/articles/nrd3478',
         }
       end
 

--- a/lib/genome/importers/ttd/ttd_tsv_importer.rb
+++ b/lib/genome/importers/ttd/ttd_tsv_importer.rb
@@ -9,7 +9,9 @@ module Genome
           source_db_version:  '4.3.02 (2011.08.25)',
           source_type_id:    DataModel::SourceType.INTERACTION,
           source_db_name:    'TTD',
-          full_name:         'Therapeutic Target Database'
+          full_name:         'Therapeutic Target Database',
+          license: 'Unclear. Website states "All Rights Reserved" but resource structure and description in 2002 publication indicate "open-access".',
+          license_link: 'https://academic.oup.com/nar/article/30/1/412/1331814',
         }
       end
 

--- a/lib/genome/online_updaters/civic/updater.rb
+++ b/lib/genome/online_updaters/civic/updater.rb
@@ -71,10 +71,12 @@ module Genome; module OnlineUpdaters; module Civic
           source_db_version: new_version,
           base_url: 'https://civic.genome.wustl.edu',
           site_url: 'https://www.civicdb.org',
-          citation: 'CIViC: Clinical Interpretations of Variants in Cancer',
+          citation: 'CIViC: Clinical Interpretation of Variants in Cancer',
           source_type_id: DataModel::SourceType.INTERACTION,
           source_trust_level_id: DataModel::SourceTrustLevel.EXPERT_CURATED,
-          full_name: 'CIViC: Clinical Interpretations of Variants in Cancer'
+          full_name: 'CIViC: Clinical Interpretation of Variants in Cancer',
+          license: 'Creative Commons Public Domain Dedication (CC0 1.0 Universal)',
+          license_url: 'https://docs.civicdb.org/en/latest/about/faq.html#how-is-civic-licensed',
         }
       )
     end

--- a/lib/genome/online_updaters/ckb/updater.rb
+++ b/lib/genome/online_updaters/ckb/updater.rb
@@ -28,6 +28,8 @@ module Genome; module OnlineUpdaters; module Ckb;
           citation: 'Sara E. Patterson, Rangjiao Liu, Cara M. Statz, Daniel Durkin, Anuradha Lakshminarayana, and Susan M. Mockus. The Clinical Trial Landscape in Oncology and Connectivity of Somatic Mutational Profiles to Targeted Therapies. Human Genomics, 2016 Jan 16;10(1):4. (PMID: 26772741)',
           source_type_id: DataModel::SourceType.INTERACTION,
           full_name: 'The Jackson Laboratory Clinical Knowledgebase',
+          license: 'Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International License',
+          license_url: 'https://ckb.jax.org/about/index',
         }
       )
     end

--- a/lib/genome/online_updaters/docm/updater.rb
+++ b/lib/genome/online_updaters/docm/updater.rb
@@ -87,7 +87,9 @@ module Genome; module OnlineUpdaters; module Docm
             source_type_id: DataModel::SourceType.INTERACTION,
             source_trust_level_id: DataModel::SourceTrustLevel.EXPERT_CURATED,
             source_db_name: 'DoCM',
-            full_name: 'Database of Curated Mutations'
+            full_name: 'Database of Curated Mutations',
+            license: 'Creative Commons Attribution 4.0 International License',
+            license_url: 'http://www.docm.info/about',
         }
       )
     end

--- a/lib/genome/online_updaters/go/updater.rb
+++ b/lib/genome/online_updaters/go/updater.rb
@@ -28,6 +28,8 @@ module Genome; module OnlineUpdaters; module Go;
           source_type_id:     DataModel::SourceType.POTENTIALLY_DRUGGABLE,
           source_db_name:     'GO',
           full_name:          'The Gene Ontology',
+          license:            'Creative Commons Attribution 4.0 Unported License',
+          license_url:        'http://geneontology.org/docs/go-citation-policy/',
         }
       )
     end

--- a/lib/genome/online_updaters/oncokb/updater.rb
+++ b/lib/genome/online_updaters/oncokb/updater.rb
@@ -28,7 +28,7 @@ module Genome; module OnlineUpdaters; module Oncokb;
           citation: 'OncoKB: A Precision Oncology Knowledge Base. Chakravarty D, Gao J, Phillips S, et. al. JCO Precision Oncology 2017 :1, 1-16',
           source_type_id: DataModel::SourceType.INTERACTION,
           full_name: 'OncoKB: A Precision Oncology Knowledge Base',
-          license: 'Custom',
+          license: 'Restrictive, non-commercial',
           license_url: 'https://www.oncokb.org/terms',
         }
       )

--- a/lib/genome/online_updaters/oncokb/updater.rb
+++ b/lib/genome/online_updaters/oncokb/updater.rb
@@ -28,6 +28,8 @@ module Genome; module OnlineUpdaters; module Oncokb;
           citation: 'OncoKB: A Precision Oncology Knowledge Base. Chakravarty D, Gao J, Phillips S, et. al. JCO Precision Oncology 2017 :1, 1-16',
           source_type_id: DataModel::SourceType.INTERACTION,
           full_name: 'OncoKB: A Precision Oncology Knowledge Base',
+          license: 'Custom',
+          license_url: 'https://www.oncokb.org/terms',
         }
       )
     end

--- a/lib/genome/updaters/chembl.rb
+++ b/lib/genome/updaters/chembl.rb
@@ -81,7 +81,9 @@ module Genome
            citation: "The ChEMBL bioactivity database: an update. Bento AP, Gaulton A, Hersey A, Bellis LJ, Chambers J, Davies M, Kruger FA, Light Y, Mak L, McGlinchey S, Nowotka M, Papadatos G, Santos R, Overington JP. Nucleic Acids Res. 42(Database issue):D1083-90. PubMed ID: 24214965",
            source_type_id: DataModel::SourceType.INTERACTION,
            source_trust_level_id: DataModel::SourceTrustLevel.EXPERT_CURATED,
-           full_name: 'The ChEMBL Bioactivity Database'
+           full_name: 'The ChEMBL Bioactivity Database',
+           license: 'Creative Commons Attribution-Share Alike 3.0 Unported License',
+           license_url: 'https://chembl.gitbook.io/chembl-interface-documentation/about',
          }
         )
       end

--- a/lib/genome/updaters/get_pubchem.rb
+++ b/lib/genome/updaters/get_pubchem.rb
@@ -124,7 +124,7 @@ module Genome
           source_db_name: 'PubChem',
           source_trust_level_id: DataModel::SourceTrustLevel.NON_CURATED,
           full_name: 'PubChem',
-          license: '',
+          license: 'Public domain',
           license_url: 'https://pubchemdocs.ncbi.nlm.nih.gov/downloads',
         ).first_or_create
       end

--- a/lib/genome/updaters/get_pubchem.rb
+++ b/lib/genome/updaters/get_pubchem.rb
@@ -123,7 +123,9 @@ module Genome
           source_type_id: DataModel::SourceType.DRUG,
           source_db_name: 'PubChem',
           source_trust_level_id: DataModel::SourceTrustLevel.NON_CURATED,
-          full_name: 'PubChem'
+          full_name: 'PubChem',
+          license: '',
+          license_url: 'https://pubchemdocs.ncbi.nlm.nih.gov/downloads',
         ).first_or_create
       end
 


### PR DESCRIPTION
There are still a lot of blanks to fill in in terms of actual licensing info but this set the framework to store this info and display it at http://dgidb.org/sources and on the individual source page. I couldn't figure out how to make the License be in a different box from the Citation on the source overview page but I think it still looks ok.