### PR TITLE
Fix query score calculation

### DIFF
--- a/app/presenters/interaction_search_results_presenter.rb
+++ b/app/presenters/interaction_search_results_presenter.rb
@@ -48,7 +48,7 @@ class InteractionSearchResultsPresenter
       promiscuity_count = DataModel::Interaction.where(identifier => result_interaction.send(identifier)).count
       pub_count = result_interaction.publications.count
       source_count = result_interaction.sources.count
-      all_promiscuity_counts = DataModel::Interaction.group(identifier).count.values
+      all_promiscuity_counts = DataModel::Interaction.group(identifier).count.values.map{|x| 1/x}
       average_promiscuity = all_promiscuity_counts.sum / all_promiscuity_counts.size.to_f
       h[result_interaction.id] = ((pub_count + source_count) * (overlap_count * average_promiscuity / promiscuity_count)).round(2)
     end


### PR DESCRIPTION
The reworked query score was missing the 1/ portion of the average
inverse promiscuity calculation.