### PR TITLE
Remove default_table_access_method config option from structure.sql file

### DIFF
--- a/db/structure.sql
+++ b/db/structure.sql
@@ -26,8 +26,6 @@ CREATE FUNCTION public.clean(text) RETURNS text
 
 SET default_tablespace = '';
 
-SET default_table_access_method = heap;
-
 --
 -- Name: ar_internal_metadata; Type: TABLE; Schema: public; Owner: -
 --


### PR DESCRIPTION
My local installation of postgres 12 results in this parameter being added to the structure.sql file. However, this option is new in version 12 of postgres and we're running 9.6 on travis-ci. I tried unsuccessfully to update our travis.yml to use 12 so this is plan B.