### PR TITLE
Performance tweaks

### DIFF
--- a/app/models/data_model/interaction.rb
+++ b/app/models/data_model/interaction.rb
@@ -25,7 +25,14 @@ module DataModel
     end
 
     def directionality
-      self.interaction_types.where.not(directionality: nil).distinct.pluck(:directionality)
+      if self.interaction_types.loaded?
+        self.interaction_types
+          .reject { |it| it.directionality.nil? }
+          .map { |it| it.directionality }
+          .uniq
+      else
+        self.interaction_types.where.not(directionality: nil).distinct.pluck(:directionality)
+      end
     end
 
     def self.for_tsv

--- a/app/presenters/interaction_search_results_presenter.rb
+++ b/app/presenters/interaction_search_results_presenter.rb
@@ -46,8 +46,8 @@ class InteractionSearchResultsPresenter
         r.interactions.values.flatten.count{|other_interaction| other_interaction.send(identifier) == result_interaction.send(identifier)}
       }.sum
       promiscuity_count = DataModel::Interaction.where(identifier => result_interaction.send(identifier)).count
-      pub_count = result_interaction.publications.count
-      source_count = result_interaction.sources.count
+      pub_count = result_interaction.publications.size
+      source_count = result_interaction.sources.size
       all_promiscuity_counts = DataModel::Interaction.group(identifier).count.values.map{|x| 1/x}
       average_promiscuity = all_promiscuity_counts.sum / all_promiscuity_counts.size.to_f
       h[result_interaction.id] = ((pub_count + source_count) * (overlap_count * average_promiscuity / promiscuity_count)).round(2)

--- a/app/presenters/interaction_search_results_presenter.rb
+++ b/app/presenters/interaction_search_results_presenter.rb
@@ -41,14 +41,21 @@ class InteractionSearchResultsPresenter
     elsif @search_context == 'drugs'
       :gene_id
     end
+
+    all_promiscuity_counts = DataModel::Interaction.group(identifier)
+      .count
+      .values
+      .map{ |x| 1.0/x }
+
     scores = result.interactions.values.flatten.each_with_object({}) do |result_interaction, h|
       overlap_count = grouped_results.map{ |r|
-        r.interactions.values.flatten.count{|other_interaction| other_interaction.send(identifier) == result_interaction.send(identifier)}
+        r.interactions.values.flatten.count{ |other_interaction| other_interaction.send(identifier) == result_interaction.send(identifier) }
       }.sum
+
+
       promiscuity_count = DataModel::Interaction.where(identifier => result_interaction.send(identifier)).count
       pub_count = result_interaction.publications.size
       source_count = result_interaction.sources.size
-      all_promiscuity_counts = DataModel::Interaction.group(identifier).count.values.map{|x| 1/x}
       average_promiscuity = all_promiscuity_counts.sum / all_promiscuity_counts.size.to_f
       h[result_interaction.id] = ((pub_count + source_count) * (overlap_count * average_promiscuity / promiscuity_count)).round(2)
     end

--- a/app/presenters/interaction_search_results_presenter.rb
+++ b/app/presenters/interaction_search_results_presenter.rb
@@ -42,21 +42,25 @@ class InteractionSearchResultsPresenter
       :gene_id
     end
 
-    all_promiscuity_counts = DataModel::Interaction.group(identifier)
+    promiscuity_counts = DataModel::Interaction.group(identifier)
       .count
+
+    all_promiscuity_scores = promiscuity_counts
       .values
       .map{ |x| 1.0/x }
 
-    scores = result.interactions.values.flatten.each_with_object({}) do |result_interaction, h|
+    average_promiscuity = all_promiscuity_scores.sum / all_promiscuity_scores.size.to_f
+    result_interactions = result.interactions.values.flatten
+
+    scores = result_interactions.each_with_object({}) do |result_interaction, h|
       overlap_count = grouped_results.map{ |r|
         r.interactions.values.flatten.count{ |other_interaction| other_interaction.send(identifier) == result_interaction.send(identifier) }
       }.sum
 
+      promiscuity_count = promiscuity_counts[result_interaction.send(identifier)]
 
-      promiscuity_count = DataModel::Interaction.where(identifier => result_interaction.send(identifier)).count
       pub_count = result_interaction.publications.size
       source_count = result_interaction.sources.size
-      average_promiscuity = all_promiscuity_counts.sum / all_promiscuity_counts.size.to_f
       h[result_interaction.id] = ((pub_count + source_count) * (overlap_count * average_promiscuity / promiscuity_count)).round(2)
     end
   end


### PR DESCRIPTION
We'll want to double check and make sure that I haven't changed the algorithm at all, but assuming this produces correct results, we're down from ~25 seconds and ~700 queries for the demo gene list to ~6  queries and ~2 seconds. Commit messages contain explanations of each step.