### PR TITLE
Revert "Fix query score calculation"

### DIFF
--- a/app/presenters/interaction_search_results_presenter.rb
+++ b/app/presenters/interaction_search_results_presenter.rb
@@ -48,7 +48,7 @@ class InteractionSearchResultsPresenter
       promiscuity_count = DataModel::Interaction.where(identifier => result_interaction.send(identifier)).count
       pub_count = result_interaction.publications.count
       source_count = result_interaction.sources.count
-      all_promiscuity_counts = DataModel::Interaction.group(identifier).count.values.map{|x| 1/x}
+      all_promiscuity_counts = DataModel::Interaction.group(identifier).count.values
       average_promiscuity = all_promiscuity_counts.sum / all_promiscuity_counts.size.to_f
       h[result_interaction.id] = ((pub_count + source_count) * (overlap_count * average_promiscuity / promiscuity_count)).round(2)
     end


### PR DESCRIPTION
Taking the average of 1/x is, in fact, incorrect and an error in the original formula in https://github.com/griffithlab/dgi-db/issues/340#issuecomment-548454105.