### PR TITLE
Initial Airbrake error reporting integration

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -26,6 +26,7 @@ gem 'rubyzip'
 gem 'kaminari', '~> 0.16.1'
 gem 'sidekiq', '~> 6.0.3'
 gem 'sidekiq-cron', '~> 1.1.0'
+gem 'airbrake', '~> 10.0.5'
 
 
 group :production do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -68,6 +68,10 @@ GEM
       zeitwerk (~> 2.2, >= 2.2.2)
     addressable (2.7.0)
       public_suffix (>= 2.0.2, < 5.0)
+    airbrake (10.0.5)
+      airbrake-ruby (~> 4.13)
+    airbrake-ruby (4.15.0)
+      rbtree3 (~> 0.5)
     airbrussh (1.4.0)
       sshkit (>= 1.6.1, != 1.7.0)
     annoy (0.5.6)
@@ -247,6 +251,7 @@ GEM
       rake (>= 0.8.7)
       thor (>= 0.20.3, < 2.0)
     rake (13.0.1)
+    rbtree3 (0.6.0)
     redis (4.1.4)
     ref (2.0.0)
     regexp_parser (1.7.0)
@@ -351,6 +356,7 @@ PLATFORMS
 
 DEPENDENCIES
   activerecord-import
+  airbrake (~> 10.0.5)
   better_errors
   binding_of_caller
   browser

--- a/config/initializers/airbrake.rb
+++ b/config/initializers/airbrake.rb
@@ -1,0 +1,73 @@
+require 'airbrake/sidekiq'
+# frozen_string_literal: true
+
+# Airbrake is an online tool that provides robust exception tracking in your Rails
+# applications. In doing so, it allows you to easily review errors, tie an error
+# to an individual piece of code, and trace the cause back to recent
+# changes. Airbrake enables for easy categorization, searching, and prioritization
+# of exceptions so that when errors occur, your team can quickly determine the
+# root cause.
+#
+# Configuration details:
+# https://github.com/airbrake/airbrake-ruby#configuration
+Airbrake.configure do |c|
+  # You must set both project_id & project_key. To find your project_id and
+  # project_key navigate to your project's General Settings and copy the values
+  # from the right sidebar.
+  # https://github.com/airbrake/airbrake-ruby#project_id--project_key
+  c.project_id = ENV['DGIDB_AIRBRAKE_PROJECT_ID'] || Rails.application.secrets.airbrake_project_id
+  c.project_key = ENV['DGIDB_AIRBRAKE_PROJECT_KEY'] || Rails.application.secrets.airbrake_project_key
+
+  # Configures the root directory of your project. Expects a String or a
+  # Pathname, which represents the path to your project. Providing this option
+  # helps us to filter out repetitive data from backtrace frames and link to
+  # GitHub files from our dashboard.
+  # https://github.com/airbrake/airbrake-ruby#root_directory
+  c.root_directory = Rails.root
+
+  # By default, Airbrake Ruby outputs to STDOUT. In Rails apps it makes sense to
+  # use the Rails' logger.
+  # https://github.com/airbrake/airbrake-ruby#logger
+  c.logger = Airbrake::Rails.logger
+
+  # Configures the environment the application is running in. Helps the Airbrake
+  # dashboard to distinguish between exceptions occurring in different
+  # environments.
+  # NOTE: This option must be set in order to make the 'ignore_environments'
+  # option work.
+  # https://github.com/airbrake/airbrake-ruby#environment
+  c.environment = Rails.env
+
+  # Setting this option allows Airbrake to filter exceptions occurring in
+  # unwanted environments such as :test.
+  # NOTE: This option *does not* work if you don't set the 'environment' option.
+  # https://github.com/airbrake/airbrake-ruby#ignore_environments
+  c.ignore_environments = %w[test development]
+
+  # A list of parameters that should be filtered out of what is sent to
+  # Airbrake. By default, all "password" attributes will have their contents
+  # replaced.
+  # https://github.com/airbrake/airbrake-ruby#blocklist_keys
+  c.blocklist_keys = [/password/i, /authorization/i]
+
+  # Alternatively, you can integrate with Rails' filter_parameters.
+  # Read more: https://goo.gl/gqQ1xS
+  # c.blocklist_keys = Rails.application.config.filter_parameters
+end
+
+# A filter that collects request body information. Enable it if you are sure you
+# don't send sensitive information to Airbrake in your body (such as passwords).
+# https://github.com/airbrake/airbrake#requestbodyfilter
+# Airbrake.add_filter(Airbrake::Rack::RequestBodyFilter.new)
+
+# Attaches thread & fiber local variables along with general thread information.
+# Airbrake.add_filter(Airbrake::Filters::ThreadFilter.new)
+
+# Attaches loaded dependencies to the notice object
+# (under context/versions/dependencies).
+# Airbrake.add_filter(Airbrake::Filters::DependencyFilter.new)
+
+# If you want to convert your log messages to Airbrake errors, we offer an
+# integration with the Logger class from stdlib.
+# https://github.com/airbrake/airbrake#logger
+# Rails.logger = Airbrake::AirbrakeLogger.new(Rails.logger)


### PR DESCRIPTION
Airbrake is one of the error tracking and notification services that Sidekiq recommends and it seems that we will comfortably fit within the free tier. It seems to be quite configurable so we may want to dial it in some as we play around with it, but this is a start.

For anyone who would like to be able to log in and see the dashboard, let me know what email address you'd like to me to use and I'll add you to the account. 

The api credentials have been added to the secrets.yml in the rails deployments repo as well.

If we like this/are happy with it, we should roll it out to civic as well.

closes #411 