### PR TITLE
Remove pharmgkb text

### DIFF
--- a/app/views/downloads/show.html.haml
+++ b/app/views/downloads/show.html.haml
@@ -48,11 +48,6 @@
             - @tsvs.each do |tsv|
               %td= raw "#{link_to tsv, file_h[tsv]}"
     %h4
-      %a{:href => "http://www.pharmgkb.org/downloads.jsp"} PharmGKB Data
-    %p
-      Note that PharmGKB is not included in the interactions TSV file above. These data must be requested directly from 
-      %a{:href => "https://www.pharmgkb.org/downloads/"} PharmGKB.
-    %h4
       %a{:href => "https://www.drugbank.ca/releases/latest"} DrugBank Data
     %p
       Note that DrugBank is not included in the interactions TSV file above. These data must be requested directly from

--- a/lib/utils/tsv.rb
+++ b/lib/utils/tsv.rb
@@ -179,7 +179,7 @@ module Utils
 
     private
     def self.license_restricted
-      @@license_restricted ||= %w[PharmGKB DrugBank]
+      @@license_restricted ||= %w[DrugBank]
     end
 
     def self.license_restricted? (source_name)


### PR DESCRIPTION
Addresses #393. Removed text for PharmGKB since its license has changed. Left DrugBank since it still has a custom license. 