### PR TITLE
Scrape Publication citations in batches

### DIFF
--- a/lib/genome/importers/cgi/new_cgi.rb
+++ b/lib/genome/importers/cgi/new_cgi.rb
@@ -125,6 +125,7 @@ module Genome; module Importers; module Cgi;
           end
         end
       end
+      backfill_publication_information()
     end
 
 

--- a/lib/genome/importers/drug_bank/new_drug_bank.rb
+++ b/lib/genome/importers/drug_bank/new_drug_bank.rb
@@ -83,6 +83,7 @@ module Genome; module Importers; module DrugBank;
         create_interaction_claim_link(interaction_claim, "Drug Target", "https://www.drugbank.ca/drugs/#{row['drug_id']}#targets")
         interaction_claim.save
       end
+      backfill_publication_information()
     end
   end
 end; end; end;

--- a/lib/genome/importers/guide_to_pharmacology_interactions/new_guide_to_pharmacology.rb
+++ b/lib/genome/importers/guide_to_pharmacology_interactions/new_guide_to_pharmacology.rb
@@ -39,6 +39,7 @@ module Genome; module Importers; module GuideToPharmacologyInteractions;
           create_interaction_claim_link(interaction_claim, "Ligand Biological Activity", "https://www.guidetopharmacology.org/GRAC/LigandDisplayForward?ligandId=#{line['ligand_id']}&tab=biology")
         end
       end
+      backfill_publication_information()
     end
 
     def valid_line?(line)

--- a/lib/genome/importers/nci/nci.rb
+++ b/lib/genome/importers/nci/nci.rb
@@ -49,6 +49,7 @@ module Genome; module Importers; module Nci;
         create_interaction_claim_publication(interaction_claim, row['PMID'])
         create_interaction_claim_link(interaction_claim, "The Cancer Gene Index Gene-Disease and Gene-Compound XML Documents", 'https://wiki.nci.nih.gov/display/cageneindex/The+Cancer+Gene+Index+Gene-Disease+and+Gene-Compound+XML+Documents')
       end
+      backfill_publication_information()
     end
   end
 end; end; end

--- a/lib/genome/importers/pharmgkb/new_pharmgkb.rb
+++ b/lib/genome/importers/pharmgkb/new_pharmgkb.rb
@@ -75,6 +75,7 @@ module Genome; module Importers; module Pharmgkb;
           end
         end
       end
+      backfill_publication_information()
     end
 
 

--- a/lib/genome/normalizers/publications.rb
+++ b/lib/genome/normalizers/publications.rb
@@ -13,24 +13,7 @@ module Genome
 						pmid.delete
 					}
 				end
-				recurrences = 0
-				# scrape pubmed
-				while (pubs_without_citations = DataModel::Publication.where(citation: nil)).length > 0 do
-					if recurrences > 0
-						sleep 300
-					end
-					pubs_without_citations.each do |pub|
-						begin
-							retries ||= 0
-							pub.citation = PMID.get_citation_from_pubmed_id(pub.pmid)
-							pub.save
-						rescue
-							sleep 1
-							retry if (retries += 1) < 3
-						end
-					end
-					recurrences += 1
-				end
+        Genome::OnlineUpdater.new().backfill_publication_information
 			end
 		end
 	end

--- a/lib/genome/online_updater.rb
+++ b/lib/genome/online_updater.rb
@@ -70,12 +70,16 @@ module Genome
       publication = DataModel::Publication.where(
         pmid: pmid
       ).first_or_create
-      if publication.citation.nil?
-        publication.citation = PMID.get_citation_from_pubmed_id(pmid)
-        publication.save
-        sleep(1)
-      end
       interaction_claim.publications << publication unless interaction_claim.publications.include? publication
+    end
+
+    def backfill_publication_information
+      DataModel::Publication.where(citation: nil).find_in_batches(batch_size: 10) do |publications|
+        PMID.get_citations_from_publications(publications).each do |publication, citation|
+          publication.citation = citation
+          publication.save
+        end
+      end
     end
 
     def create_interaction_claim_attribute(interaction_claim, name, value)

--- a/lib/genome/online_updaters/civic/updater.rb
+++ b/lib/genome/online_updaters/civic/updater.rb
@@ -23,6 +23,7 @@ module Genome; module OnlineUpdaters; module Civic
           create_entries_for_evidence_item(variant, ei, source)
         end
       end
+      backfill_publication_information()
     end
 
     def importable_eid?(evidence_item)

--- a/lib/genome/online_updaters/ckb/updater.rb
+++ b/lib/genome/online_updaters/ckb/updater.rb
@@ -60,6 +60,7 @@ module Genome; module OnlineUpdaters; module Ckb;
           end
         end
       end
+      backfill_publication_information()
     end
 
     def create_gene_claim_aliases(gene_claim, gene)

--- a/lib/genome/online_updaters/docm/updater.rb
+++ b/lib/genome/online_updaters/docm/updater.rb
@@ -29,6 +29,7 @@ module Genome; module OnlineUpdaters; module Docm
           create_interaction_claim_link(ic, "DoCM Website", 'http://docm.info')
         end
       end
+      backfill_publication_information()
     end
 
     def parse_interaction_information(variant)


### PR DESCRIPTION
The `create_interaction_claim_publication` method now does not immediately scrape PubMed for the citation. Instead this PR adds a new method `backfill_publication_information` which backfills all Publications without a citation but does so in batches. The PubMedAPI allows for queries with multiple PubMed IDs. Right now it queries 10 at a time but we can play around with this (it does seem pretty fast).

For any new importers, we will need to remember to call `backfill_publication_information` once after all the interactions are imported.