### PR TITLE
Add a new option to the interaction grouper to control whether or not to group from scratch

### DIFF
--- a/lib/genome/groupers/interaction_grouper.rb
+++ b/lib/genome/groupers/interaction_grouper.rb
@@ -21,12 +21,9 @@ module Genome
       end
 
       def self.add_members
-        DataModel::InteractionClaim.where(interaction_id: nil).each do |interaction_claim|
-          next unless interaction_claim.interaction.nil?
+        DataModel::InteractionClaim.joins(drug_claim: [:drug], gene_claim: [:gene]).where(interaction_id: nil).each do |interaction_claim|
           drug = interaction_claim.drug_claim.drug
-          next if drug.nil?
           gene = interaction_claim.gene_claim.gene
-          next if gene.nil?
           interaction = DataModel::Interaction.where(drug_id: drug.id, gene_id: gene.id).first_or_create
           interaction_claim.interaction = interaction
           interaction_claim.interaction_claim_types.each do |t|


### PR DESCRIPTION
This option is turned off by default so it will only group interaction claims without an interaction_id. This should speed up this grouping step for the online updaters significantly.