### PR TITLE
Import of DTC data with some small improvements to importers

### DIFF
--- a/config/scheduled_tasks.yml
+++ b/config/scheduled_tasks.yml
@@ -41,12 +41,6 @@ UpdatePharmGKB:
   queue: default
   class: UpdatePharmgkb
 
-UpdateDtc:
-  cron: '0 7 1 * *'
-  description: Update data from Drug Target Commons
-  queue: default
-  class: UpdateDtc
-
 #Tasks to execute every 14th and 28th of the month (closest to every two weeks
 #possible in cron notation)
 UpdateCivic:

--- a/lib/genome/importers/dtc/dtc.rb
+++ b/lib/genome/importers/dtc/dtc.rb
@@ -55,10 +55,10 @@ class DtcImporter < Genome::OnlineUpdater
         gene_name.split(',').each do |indv_gene|
           gene_claim = create_gene_claim(indv_gene, 'DTC Gene Name')
           interaction_claim = create_interaction_claim(gene_claim, drug_claim)
-          unless pmid.nil? || pmid == '""' || pmid == "''" || pmid[0] =='-' || pmid =='15288657'
-            create_interaction_claim_publication(interaction_claim, row['pubmed_id'])
+          unless pmid.nil? || pmid == "" || pmid == '""' || pmid == "''" || pmid[0] =='-' || pmid =='15288657'
+            create_interaction_claim_publication(interaction_claim, pmid)
           end
-          unless mechanism.nil?
+          unless mechanism.nil? || mechanism == ""
             create_interaction_claim_type(interaction_claim, mechanism)
           end
           create_interaction_claim_link(interaction_claim, 'Drug Target Commons Interactions', 'https://drugtargetcommons.fimm.fi/')

--- a/lib/genome/online_updater.rb
+++ b/lib/genome/online_updater.rb
@@ -81,6 +81,9 @@ module Genome
         end
         sleep(0.3)
       end
+      DataModel::Publication.where(citation: "").each do |publication|
+        publication.destroy
+      end
     end
 
     def create_interaction_claim_attribute(interaction_claim, name, value)

--- a/lib/genome/online_updater.rb
+++ b/lib/genome/online_updater.rb
@@ -74,11 +74,12 @@ module Genome
     end
 
     def backfill_publication_information
-      DataModel::Publication.where(citation: nil).find_in_batches(batch_size: 10) do |publications|
+      DataModel::Publication.where(citation: nil).find_in_batches(batch_size: 100) do |publications|
         PMID.get_citations_from_publications(publications).each do |publication, citation|
           publication.citation = citation
           publication.save
         end
+        sleep(0.3)
       end
     end
 

--- a/lib/utils/pmid.rb
+++ b/lib/utils/pmid.rb
@@ -39,7 +39,11 @@ module PMID
     end
 
     def citation
-      [first_author, year, article_title, journal].compact.join(', ')
+      if result.has_key? 'authors'
+        [first_author, year, article_title, journal].compact.join(', ')
+      else
+        ""
+      end
     end
 
     def authors


### PR DESCRIPTION
I ended up having the pre-process the DTC to remove entries that are "unimportable". To do that I ran the following:

```
cat ~/Downloads/DTC_data.csv | python -c'import csv; import sys; reader = csv.reader(sys.stdin, delimiter=",", quotechar="\""); mylist = set(["\"{}\",\"{}\",\"{}\",\"{}\"".format(row[2], row[6], row[9], row[15]) for row in reader if row[2] is not None and row[2] != "" and row[6] is not None and row[6] != ""]); print("\n".join(list(mylist)))' > DTC_data.short.csv
```

I added this file to the data subrepo as well.