### PR TITLE
Some additional improvements to the interaction grouper

### DIFF
--- a/lib/genome/groupers/interaction_grouper.rb
+++ b/lib/genome/groupers/interaction_grouper.rb
@@ -1,19 +1,17 @@
 module Genome
   module Groupers
     class InteractionGrouper
-      attr_reader :group_from_scratch
       def self.run(group_from_scratch=false)
-        @group_from_scratch = group_from_scratch
         if group_from_scratch
           ActiveRecord::Base.transaction do
             puts 'reset members'
             reset_members
             puts 'add members'
-            add_members
+            add_members(group_from_scratch)
           end
         else
           puts 'add members'
-          add_members
+          add_members(group_from_scratch)
         end
       end
 
@@ -23,9 +21,9 @@ module Genome
         DataModel::Interaction.destroy_all
       end
 
-      def self.add_members
+      def self.add_members(group_from_scratch)
         DataModel::InteractionClaim.eager_load(:interaction_claim_types, :source, :interaction_claim_attributes, :publications).joins(drug_claim: [:drug], gene_claim: [:gene]).where(interaction_id: nil).each do |interaction_claim|
-          if @group_from_scratch
+          if group_from_scratch
             add_member(interaction_claim)
           else
             ActiveRecord::Base.transaction do

--- a/lib/genome/groupers/interaction_grouper.rb
+++ b/lib/genome/groupers/interaction_grouper.rb
@@ -1,16 +1,19 @@
 module Genome
   module Groupers
     class InteractionGrouper
+      attr_reader :group_from_scratch
       def self.run(group_from_scratch=false)
-        ActiveRecord::Base.transaction do
-          if group_from_scratch
+        @group_from_scratch = group_from_scratch
+        if group_from_scratch
+          ActiveRecord::Base.transaction do
             puts 'reset members'
             reset_members
+            puts 'add members'
+            add_members
           end
+        else
           puts 'add members'
           add_members
-          puts 'add attributes'
-          add_attributes
         end
       end
 
@@ -21,49 +24,59 @@ module Genome
       end
 
       def self.add_members
-        DataModel::InteractionClaim.joins(drug_claim: [:drug], gene_claim: [:gene]).where(interaction_id: nil).each do |interaction_claim|
-          drug = interaction_claim.drug_claim.drug
-          gene = interaction_claim.gene_claim.gene
-          interaction = DataModel::Interaction.where(drug_id: drug.id, gene_id: gene.id).first_or_create
-          interaction_claim.interaction = interaction
-          interaction_claim.interaction_claim_types.each do |t|
-            unless interaction.interaction_types.include? t
-              interaction.interaction_types << t
+        DataModel::InteractionClaim.eager_load(:interaction_claim_types, :source, :interaction_claim_attributes, :publications).joins(drug_claim: [:drug], gene_claim: [:gene]).where(interaction_id: nil).each do |interaction_claim|
+          if @group_from_scratch
+            add_member(interaction_claim)
+          else
+            ActiveRecord::Base.transaction do
+              add_member(interaction_claim)
             end
           end
-          interaction_claim.save
-          interaction.save
         end
       end
 
-      def self.add_attributes
-        DataModel::Interaction.all.each do |interaction|
-          interaction.interaction_claims.each do |interaction_claim|
-            # roll sources up to interaction level
-            unless interaction.sources.include? interaction_claim.source
-              interaction.sources << interaction_claim.source
-            end
-            interaction_claim.interaction_claim_attributes.each do |ica|
-              interaction_attribute = DataModel::InteractionAttribute.where(
-                interaction_id: interaction.id,
-                name: ica.name,
-                value: ica.value
-              ).first_or_create
-              unless interaction_attribute.sources.include? interaction_claim.source
-                interaction_attribute.sources << interaction_claim.source
-              end
-            end
-            #roll publications up to interaction level
-            interaction_claim.publications.each do |pub|
-              interaction.publications << pub unless interaction.publications.include? pub
-            end
-            # these actions might be unnecessary if we create interaction types and publications directly
-            DataModel::InteractionAttribute.where(name: 'PMID').destroy_all
-            DataModel::InteractionAttribute.where(name: 'PubMed ID for Interaction').destroy_all
-            DataModel::InteractionAttribute.where(name: 'Interaction Type').destroy_all
+      def self.add_member(interaction_claim)
+        drug = interaction_claim.drug_claim.drug
+        gene = interaction_claim.gene_claim.gene
+        interaction = DataModel::Interaction.where(drug_id: drug.id, gene_id: gene.id).first_or_create
+        interaction_claim.interaction = interaction
+        interaction_claim.save
+
+        #roll types up to interaction level
+        interaction_claim.interaction_claim_types.each do |t|
+          unless interaction.interaction_types.include? t
+            interaction.interaction_types << t
           end
         end
+
+        #roll sources up to interaction level
+        unless interaction.sources.include? interaction_claim.source
+          interaction.sources << interaction_claim.source
+        end
+
+        #roll attributes up to interaction level
+        interaction_claim.interaction_claim_attributes.each do |ica|
+          interaction_attribute = DataModel::InteractionAttribute.where(
+            interaction_id: interaction.id,
+            name: ica.name,
+            value: ica.value
+          ).first_or_create
+          unless interaction_attribute.sources.include? interaction_claim.source
+            interaction_attribute.sources << interaction_claim.source
+          end
+        end
+
+        #roll publications up to interaction level
+        interaction_claim.publications.each do |pub|
+          interaction.publications << pub unless interaction.publications.include? pub
+        end
+
+        interaction.save
       end
+      # these actions might be unnecessary if we create interaction types and publications directly
+      DataModel::InteractionAttribute.where(name: 'PMID').destroy_all
+      DataModel::InteractionAttribute.where(name: 'PubMed ID for Interaction').destroy_all
+      DataModel::InteractionAttribute.where(name: 'Interaction Type').destroy_all
     end
   end
 end

--- a/lib/genome/groupers/interaction_grouper.rb
+++ b/lib/genome/groupers/interaction_grouper.rb
@@ -22,12 +22,14 @@ module Genome
       end
 
       def self.add_members(group_from_scratch)
-        DataModel::InteractionClaim.eager_load(:interaction_claim_types, :source, :interaction_claim_attributes, :publications).joins(drug_claim: [:drug], gene_claim: [:gene]).where(interaction_id: nil).each do |interaction_claim|
-          if group_from_scratch
-            add_member(interaction_claim)
-          else
-            ActiveRecord::Base.transaction do
+        DataModel::InteractionClaim.eager_load(:interaction_claim_types, :source, :interaction_claim_attributes, :publications).joins(drug_claim: [:drug], gene_claim: [:gene]).where(interaction_id: nil).in_batches do |interaction_claims|
+          interaction_claims.each do |interaction_claim|
+            if group_from_scratch
               add_member(interaction_claim)
+            else
+              ActiveRecord::Base.transaction do
+                add_member(interaction_claim)
+              end
             end
           end
         end

--- a/lib/genome/groupers/interaction_grouper.rb
+++ b/lib/genome/groupers/interaction_grouper.rb
@@ -33,6 +33,10 @@ module Genome
             end
           end
         end
+        # these actions might be unnecessary if we create interaction types and publications directly
+        DataModel::InteractionAttribute.where(name: 'PMID').destroy_all
+        DataModel::InteractionAttribute.where(name: 'PubMed ID for Interaction').destroy_all
+        DataModel::InteractionAttribute.where(name: 'Interaction Type').destroy_all
       end
 
       def self.add_member(interaction_claim)
@@ -40,7 +44,6 @@ module Genome
         gene = interaction_claim.gene_claim.gene
         interaction = DataModel::Interaction.where(drug_id: drug.id, gene_id: gene.id).first_or_create
         interaction_claim.interaction = interaction
-        interaction_claim.save
 
         #roll types up to interaction level
         interaction_claim.interaction_claim_types.each do |t|
@@ -71,12 +74,9 @@ module Genome
           interaction.publications << pub unless interaction.publications.include? pub
         end
 
+        interaction_claim.save
         interaction.save
       end
-      # these actions might be unnecessary if we create interaction types and publications directly
-      DataModel::InteractionAttribute.where(name: 'PMID').destroy_all
-      DataModel::InteractionAttribute.where(name: 'PubMed ID for Interaction').destroy_all
-      DataModel::InteractionAttribute.where(name: 'Interaction Type').destroy_all
     end
   end
 end


### PR DESCRIPTION
This PR mainly pulls up the code from `add_attributes` into the `add_member` method so that it only processes the attributes for newly created interactions. If we don't group from scratch I also moved the transaction to not happen around the whole process but one transaction for each interaction claim. This will make it so that you don't loose all the progress already made if a job fails or has to be aborted.

I also added an eager load for related tables on interaction claims in the hope that that will result in less SQL queries having to be executed.

This code is untested but I wanted to put it out there to get other people's opinions.