### PR TITLE
Interaction grouper improvements without CI failures

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,7 +1,7 @@
 name: Unit Tests
 on:
   push:
-    branches: [ master, staging ]
+    branches: '**'
   pull_request:
     branches: [ master, staging]
 

--- a/lib/genome/groupers/interaction_grouper.rb
+++ b/lib/genome/groupers/interaction_grouper.rb
@@ -9,8 +9,6 @@ module Genome
           end
           puts 'add members'
           add_members
-          puts 'add attributes'
-          add_attributes
         end
       end
 
@@ -22,47 +20,50 @@ module Genome
 
       def self.add_members
         DataModel::InteractionClaim.eager_load(:interaction_claim_types, :source, :interaction_claim_attributes, :publications).joins(drug_claim: [:drug], gene_claim: [:gene]).where(interaction_id: nil).each do |interaction_claim|
-          drug = interaction_claim.drug_claim.drug
-          gene = interaction_claim.gene_claim.gene
-          interaction = DataModel::Interaction.where(drug_id: drug.id, gene_id: gene.id).first_or_create
-          interaction_claim.interaction = interaction
-          interaction_claim.interaction_claim_types.each do |t|
-            unless interaction.interaction_types.include? t
-              interaction.interaction_types << t
-            end
-          end
-          interaction_claim.save
-          interaction.save
+          self.add_member(interaction_claim)
         end
       end
 
-      def self.add_attributes
-        DataModel::Interaction.all.each do |interaction|
-          interaction.interaction_claims.each do |interaction_claim|
-            # roll sources up to interaction level
-            unless interaction.sources.include? interaction_claim.source
-              interaction.sources << interaction_claim.source
-            end
-            interaction_claim.interaction_claim_attributes.each do |ica|
-              interaction_attribute = DataModel::InteractionAttribute.where(
-                interaction_id: interaction.id,
-                name: ica.name,
-                value: ica.value
-              ).first_or_create
-              unless interaction_attribute.sources.include? interaction_claim.source
-                interaction_attribute.sources << interaction_claim.source
-              end
-            end
-            #roll publications up to interaction level
-            interaction_claim.publications.each do |pub|
-              interaction.publications << pub unless interaction.publications.include? pub
-            end
-            # these actions might be unnecessary if we create interaction types and publications directly
-            DataModel::InteractionAttribute.where(name: 'PMID').destroy_all
-            DataModel::InteractionAttribute.where(name: 'PubMed ID for Interaction').destroy_all
-            DataModel::InteractionAttribute.where(name: 'Interaction Type').destroy_all
+      def self.add_member(interaction_claim)
+        drug = interaction_claim.drug_claim.drug
+        gene = interaction_claim.gene_claim.gene
+        interaction = DataModel::Interaction.where(drug_id: drug.id, gene_id: gene.id).first_or_create
+        interaction_claim.interaction = interaction
+
+        #roll types up to interaction level
+        interaction_claim.interaction_claim_types.each do |t|
+          unless interaction.interaction_types.include? t
+            interaction.interaction_types << t
           end
         end
+
+        # roll sources up to interaction level
+        unless interaction.sources.include? interaction_claim.source
+          interaction.sources << interaction_claim.source
+        end
+        interaction_claim.interaction_claim_attributes.each do |ica|
+          interaction_attribute = DataModel::InteractionAttribute.where(
+            interaction_id: interaction.id,
+            name: ica.name,
+            value: ica.value
+          ).first_or_create
+          unless interaction_attribute.sources.include? interaction_claim.source
+            interaction_attribute.sources << interaction_claim.source
+          end
+        end
+
+        #roll publications up to interaction level
+        interaction_claim.publications.each do |pub|
+          interaction.publications << pub unless interaction.publications.include? pub
+        end
+
+        interaction_claim.save
+        interaction.save
+
+        # these actions might be unnecessary if we create interaction types and publications directly
+        DataModel::InteractionAttribute.where(name: 'PMID').destroy_all
+        DataModel::InteractionAttribute.where(name: 'PubMed ID for Interaction').destroy_all
+        DataModel::InteractionAttribute.where(name: 'Interaction Type').destroy_all
       end
     end
   end

--- a/lib/genome/groupers/interaction_grouper.rb
+++ b/lib/genome/groupers/interaction_grouper.rb
@@ -19,8 +19,10 @@ module Genome
       end
 
       def self.add_members
-        DataModel::InteractionClaim.eager_load(:interaction_claim_types, :source, :interaction_claim_attributes, :publications).joins(drug_claim: [:drug], gene_claim: [:gene]).where(interaction_id: nil).each do |interaction_claim|
-          self.add_member(interaction_claim)
+        DataModel::InteractionClaim.eager_load(:interaction_claim_types, :source, :interaction_claim_attributes, :publications).joins(drug_claim: [:drug], gene_claim: [:gene]).where(interaction_id: nil).in_batches do |interaction_claims|
+          interaction_claims.each do |interaction_claim|
+            add_member(interaction_claim)
+          end
         end
       end
 

--- a/lib/genome/groupers/interaction_grouper.rb
+++ b/lib/genome/groupers/interaction_grouper.rb
@@ -21,7 +21,7 @@ module Genome
       end
 
       def self.add_members
-        DataModel::InteractionClaim.joins(drug_claim: [:drug], gene_claim: [:gene]).where(interaction_id: nil).each do |interaction_claim|
+        DataModel::InteractionClaim.eager_load(:interaction_claim_types, :source, :interaction_claim_attributes, :publications).joins(drug_claim: [:drug], gene_claim: [:gene]).where(interaction_id: nil).each do |interaction_claim|
           drug = interaction_claim.drug_claim.drug
           gene = interaction_claim.gene_claim.gene
           interaction = DataModel::Interaction.where(drug_id: drug.id, gene_id: gene.id).first_or_create


### PR DESCRIPTION
Something about https://github.com/griffithlab/dgi-db/pull/457 is causing persistent CI failures. This PR is almost identical but doesn't cause failures. This PR replaces #457 