### PR TITLE
Add soure as an attribute to online updaters

### DIFF
--- a/lib/genome/online_updaters/ckb/updater.rb
+++ b/lib/genome/online_updaters/ckb/updater.rb
@@ -2,7 +2,7 @@ require 'genome/online_updater'
 
 module Genome; module OnlineUpdaters; module Ckb;
   class Updater < Genome::OnlineUpdater
-    attr_reader :new_version
+    attr_reader :new_version, :source
     def initialize(source_db_version = Date.today.strftime("%d-%B-%Y"))
       @new_version = source_db_version
     end

--- a/lib/genome/online_updaters/docm/updater.rb
+++ b/lib/genome/online_updaters/docm/updater.rb
@@ -2,7 +2,7 @@ require 'genome/online_updater'
 
 module Genome; module OnlineUpdaters; module Docm
   class Updater < Genome::OnlineUpdater
-    attr_reader :new_version
+    attr_reader :new_version, :source
     def initialize(source_db_version = Date.today.strftime("%d-%B-%Y"))
       @new_version = source_db_version
     end

--- a/lib/genome/online_updaters/go/updater.rb
+++ b/lib/genome/online_updaters/go/updater.rb
@@ -2,7 +2,7 @@ require 'genome/online_updater'
 
 module Genome; module OnlineUpdaters; module Go;
   class Updater < Genome::OnlineUpdater
-    attr_reader :new_version
+    attr_reader :new_version, :source
     def initialize(source_db_version = Date.today.strftime("%d-%B-%Y"))
       @new_version = source_db_version
     end

--- a/lib/genome/online_updaters/oncokb/updater.rb
+++ b/lib/genome/online_updaters/oncokb/updater.rb
@@ -2,7 +2,7 @@ require 'genome/online_updater'
 
 module Genome; module OnlineUpdaters; module Oncokb;
   class Updater < Genome::OnlineUpdater
-    attr_reader :new_version
+    attr_reader :new_version, :source
     def initialize(source_db_version = Date.today.strftime("%d-%B-%Y"))
       @new_version = source_db_version
     end

--- a/lib/genome/online_updaters/pharos/updater.rb
+++ b/lib/genome/online_updaters/pharos/updater.rb
@@ -2,7 +2,7 @@ require 'genome/online_updater'
 
 module Genome; module OnlineUpdaters; module Pharos;
   class Updater < Genome::OnlineUpdater
-    attr_reader :new_version
+    attr_reader :new_version, :source
     def initialize(source_db_version = Date.today.strftime("%d-%B-%Y"))
       @new_version = source_db_version
     end


### PR DESCRIPTION
The missing attributes will be causing errors in the online updaters when it attempts to run the drug grouper (as seen on staging).