### PR TITLE
Remove unsourced attributes, aliases, and interactions (includes data dump)

### DIFF
--- a/lib/genome/groupers/drug_grouper.rb
+++ b/lib/genome/groupers/drug_grouper.rb
@@ -104,6 +104,9 @@ module Genome
             drug_claim.save
           end
         end
+        Utils::Database.destroy_empty_groups
+        Utils::Database.destroy_unsourced_attributes
+        Utils::Database.destroy_unsourced_aliases
       end
 
       def query_drug_claim_aliases(drug_claim_aliases)

--- a/lib/genome/groupers/gene_grouper.rb
+++ b/lib/genome/groupers/gene_grouper.rb
@@ -15,6 +15,9 @@ module Genome
             end
           end
         end until newly_added_claims_count == 0
+        Utils::Database.destroy_empty_groups
+        Utils::Database.destroy_unsourced_attributes
+        Utils::Database.destroy_unsourced_aliases
       end
 
       def add_members(claims)

--- a/lib/genome/groupers/interaction_grouper.rb
+++ b/lib/genome/groupers/interaction_grouper.rb
@@ -13,6 +13,9 @@ module Genome
           puts 'add members'
           add_members(group_from_scratch)
         end
+        Utils::Database.destroy_empty_groups
+        Utils::Database.destroy_unsourced_attributes
+        Utils::Database.destroy_unsourced_aliases
       end
 
       def self.reset_members

--- a/lib/utils/database.rb
+++ b/lib/utils/database.rb
@@ -94,6 +94,9 @@ module Utils
 
         ActiveRecord::Base.connection.execute(sql)
       end
+      destroy_empty_groups
+      destroy_unsourced_attributes
+      destroy_unsourced_aliases
     end
 
     def self.destroy_common_aliases
@@ -116,6 +119,20 @@ module Utils
       # empty_genes = DataModel::Gene.includes(:gene_claims).where(gene_claims: {id: nil}).destroy_all
       # Empty drugs are okay to delete
       DataModel::Drug.includes(:drug_claims).where(drug_claims: {id: nil}).destroy_all
+    end
+
+    def self.destroy_unsourced_attributes
+      DataModel::InteractionAttribute.includes(:sources).where(sources: {id: nil}).destroy_all
+      DataModel::GeneAttribute.includes(:sources).where(sources: {id: nil}).destroy_all
+      DataModel::DrugAttribute.includes(:sources).where(sources: {id: nil}).destroy_all
+    end
+
+    def self.destroy_unsourced_aliases
+      DataModel::GeneAlias.includes(:sources).where(sources: {id: nil}).destroy_all
+      #Drug aliases are currently imported directly from the therapy
+      #normalizer but not attributed to ChEMBL or Wikidata (outstanding issue #485)
+      #Therefore, none of the drug aliases currently have a source
+      #DataModel::DrugAlias.includes(:sources).where(sources: {id: nil}).destroy_all
     end
 
     def self.destroy_na


### PR DESCRIPTION
Closes #534  and #528.