### PR TITLE
Don't generate and upload release TSVs when uploading a new data dump to remote

### DIFF
--- a/lib/capistrano/tasks/db.rake
+++ b/lib/capistrano/tasks/db.rake
@@ -7,9 +7,6 @@ namespace :db do
     on roles(:all) do
       upload!('data/data.sql', "#{shared_path}/public/data/data.sql")
       upload!('data/dGene_04-16-2013_2257.tsv', "#{shared_path}/public/data/dGene_04-16-2013_2257.tsv")
-      %w(interactions categories genes drugs).each do |type|
-        upload!("data/#{type}.tsv", "#{shared_path}/public/data/#{type}.tsv")
-      end
     end
   end
   before 'copy_data_to_remote', 'deploy:update_data_submodule'


### PR DESCRIPTION
Now that we auto-generate monthly releases we don't need to create the release TSVs whenever we upload a new data dump.