### PR TITLE
Fix Show All/Less/More buttons in the interaction search results

### DIFF
--- a/app/views/interaction_claims/_interactions_search_panel.html.haml
+++ b/app/views/interaction_claims/_interactions_search_panel.html.haml
@@ -26,7 +26,7 @@
       %h4{style: "display: inline-block;"}
       - interactions = filtered_interactions.sort_by { |i| -scores[i.id] }.map{|i| InteractionPresenter.new(i)}
       - if interactions.count > 0
-        %table{class: "search_panel table table-condensed table-striped", style: "width: 100%; margin-top: -20px;"}
+        %table{class: "search_panel table table-condensed table-striped", style: "width: 100%; margin-top: -20px;", id: "#{term}-#{entity.name}"}
           %tr
             %th
               - if @search_mode == "genes"
@@ -67,11 +67,11 @@
                 = scores[interaction.id]
               %td
                 = interaction.interaction_score(known_drug_partners_per_gene, known_gene_partners_per_drug).round(2)
-        %button{class: "show-all", style: "margin-top: 5px"}
+        %button{class: "show-all", style: "margin-top: 5px", value: "#{term}-#{entity.name}"}
           Show All
-        %button{class: "show-more", style: "margin-top: 5px"}
+        %button{class: "show-more", style: "margin-top: 5px", value: "#{term}-#{entity.name}"}
           Show More
-        %button{class: "show-less", style: "margin-top: 5px"}
+        %button{class: "show-less", style: "margin-top: 5px", value: "#{term}-#{entity.name}"}
           Show Less
         %span{style: "display: inline-block; margin-top: 5px; margin-left: 5px"}
           Showing

--- a/app/views/interaction_claims/interaction_search_results.html.haml
+++ b/app/views/interaction_claims/interaction_search_results.html.haml
@@ -59,18 +59,21 @@
   $('table').each(function(index){
     $(this).find('> tbody > tr').hide().slice(0, 11).show();
   });
-  $(".show-all").on("click", function() {
-    var tbl = $('table');
+  $(".show-all").on("click", function(context) {
+    var table_id = context.target.value
+    var tbl = $('#'.concat(table_id));
     $("tbody > tr", tbl).show();
     $("#nrows", $(this).next().next().next()).html(tbl.find('tr:visible').length - 1);
   });
-  $(".show-more").on("click", function() {
-    var tbl = $('table');
+  $(".show-more").on("click", function(context) {
+    var table_id = context.target.value
+    var tbl = $('#'.concat(table_id));
     $("tbody > tr", tbl).slice(0, tbl.find('tr:visible').length + 10).show();
     $("#nrows", $(this).next().next()).html(tbl.find('tr:visible').length - 1);
   });
-  $(".show-less").on("click", function() {
-    var tbl = $('table');
+  $(".show-less").on("click", function(context) {
+    var table_id = context.target.value
+    var tbl = $('#'.concat(table_id));
     tbl.find('> tbody > tr').hide().slice(0, 11).show();
     $("#nrows", $(this).next()).html(tbl.find('tr:visible').length - 1);
   });


### PR DESCRIPTION
Closes #357.

The original code wasn't picking any of the particular result tables and applying the button action to all of them at the same time and then counting the rows for all tables. This code now assigns a unique id for each table. The buttons have a `value` matching the id of the respective table and the button action applies the action to only the table with that id.