### PR TITLE
Speed up interaction search

### DIFF
--- a/app/views/interaction_claims/_interaction_search_failed.html.haml
+++ b/app/views/interaction_claims/_interaction_search_failed.html.haml
@@ -38,7 +38,7 @@
       - ambiguous_matches.each do |result|
         - result[:identifiers].each do |entity|
           %li{class: "interaction interaction-panel", "data-category" => "interaction", "data-name" => "Interaction", id: entity.name + "-ambiguous", style: "display: list-item; width: 100%;"}
-            = render partial: 'interaction_claims/interactions_search_panel', locals: { term: result[:term], entity: entity, filtered_interactions: result[:interactions][entity].to_a, scores: result[:scores]  }
+            = render partial: 'interaction_claims/interactions_search_panel', locals: { term: result[:term], entity: entity, filtered_interactions: result[:interactions][entity].to_a, scores: result[:scores], known_drug_partners_per_gene: known_drug_partners_per_gene, known_gene_partners_per_drug: known_gene_partners_per_drug  }
     - else 
       %li{class: "interaction interaction-panel", "data-category" => "interaction", "data-name" => "Interaction", style: "width: 100%; height: 300px;"}
         %h3{style: "margin-left: 20px;"}

--- a/app/views/interaction_claims/_interaction_search_successful.html.haml
+++ b/app/views/interaction_claims/_interaction_search_successful.html.haml
@@ -29,7 +29,7 @@
       - definite_matches.each do |result|
         - result[:identifiers].each do |entity|
           %li{class: "interaction interaction-panel", "data-category" => "interaction", "data-name" => "Interaction", id: entity.name + "-unique", style: "width: 100%;"}
-            = render partial: 'interaction_claims/interactions_search_panel', locals: { term: result[:term], entity: entity, filtered_interactions: result[:interactions][entity].to_a, scores: result[:scores] }
+            = render partial: 'interaction_claims/interactions_search_panel', locals: { term: result[:term], entity: entity, filtered_interactions: result[:interactions][entity].to_a, scores: result[:scores], known_drug_partners_per_gene: known_drug_partners_per_gene, known_gene_partners_per_drug: known_gene_partners_per_drug }
     - else 
       %li{class: "interaction interaction-panel", "data-category" => "interaction", "data-name" => "Interaction", style: "width: 100%; height: 300px;"}
         %h3{style: "margin-left: 20px;"}

--- a/app/views/interaction_claims/_interactions_search_panel.html.haml
+++ b/app/views/interaction_claims/_interactions_search_panel.html.haml
@@ -3,9 +3,6 @@
 - else
   - entity = DrugPresenter.new(entity)
 
-- known_drug_partners_per_gene = DataModel::Interaction.group(:gene_id).count
-- known_gene_partners_per_drug = DataModel::Interaction.group(:drug_id).count
-
 %div(class="item-title")
   %div(class="item-name")
     %h3(class="item-source")

--- a/app/views/interaction_claims/interaction_search_results.html.haml
+++ b/app/views/interaction_claims/interaction_search_results.html.haml
@@ -1,3 +1,6 @@
+- known_drug_partners_per_gene = DataModel::Interaction.group(:gene_id).count
+- known_gene_partners_per_drug = DataModel::Interaction.group(:drug_id).count
+
 #notice= notice
 =content_for :title do
   =tx "title"
@@ -30,7 +33,7 @@
           .span12
             - definite_results = @search_results.definite_results
             - definite_no_interactions = @search_results.definite_no_interactions
-            = render partial: 'interaction_claims/interaction_search_successful', locals: {definite_results: definite_results, definite_no_interactions: definite_no_interactions} #use @search_mode to determine type of view, just use one set of templates
+            = render partial: 'interaction_claims/interaction_search_successful', locals: {definite_results: definite_results, definite_no_interactions: definite_no_interactions, known_drug_partners_per_gene: known_drug_partners_per_gene, known_gene_partners_per_drug: known_gene_partners_per_drug} #use @search_mode to determine type of view, just use one set of templates
 
       .tab-pane.fade#failed
         .row-fluid#container
@@ -42,7 +45,7 @@
               - failed_terms = failed_results.flat_map{|result| result.search_terms}
             - else
               - failed_terms = []
-            = render partial: 'interaction_claims/interaction_search_failed', locals: {ambiguous_results: ambiguous_results, ambiguous_no_interactions: ambiguous_no_interactions, failed_terms: failed_terms}
+            = render partial: 'interaction_claims/interaction_search_failed', locals: {ambiguous_results: ambiguous_results, ambiguous_no_interactions: ambiguous_no_interactions, failed_terms: failed_terms, known_drug_partners_per_gene: known_drug_partners_per_gene, known_gene_partners_per_drug: known_gene_partners_per_drug}
 
 
 :javascript


### PR DESCRIPTION
`known_gene_partners_per_drug` and `known_drug_partners_per_gene` were previously calculated once per search result match. This change calculates it ones per search.