### PR TITLE
Clean up gene categories that no longer have a matching gene claim category after source reimport (includes data dump)

### DIFF
--- a/lib/genome/groupers/gene_grouper.rb
+++ b/lib/genome/groupers/gene_grouper.rb
@@ -18,6 +18,7 @@ module Genome
         Utils::Database.destroy_empty_groups
         Utils::Database.destroy_unsourced_attributes
         Utils::Database.destroy_unsourced_aliases
+        Utils::Database.destroy_unsourced_gene_categories
       end
 
       def add_members(claims)

--- a/lib/genome/groupers/interaction_grouper.rb
+++ b/lib/genome/groupers/interaction_grouper.rb
@@ -16,6 +16,7 @@ module Genome
         Utils::Database.destroy_empty_groups
         Utils::Database.destroy_unsourced_attributes
         Utils::Database.destroy_unsourced_aliases
+        Utils::Database.destroy_unsourced_gene_categories
       end
 
       def self.reset_members


### PR DESCRIPTION
I noticed that we have some genes that have a mismatch in categories depending on whether you do a category search or look at the gene summary directly. The first view is based on the underlying gene claims' categories and the latter is based on the gene categories directly (see https://dgidb.org/categories_search_results?genes=TRRAP#_successful and https://dgidb.org/genes/TRRAP for an example). This PR updated the database utils to delete extra gene categories after source deletion as well as interaction and gene grouping. It also updated the data dump to delete existing extraneous gene categories.

This is similar to the work done in https://github.com/griffithlab/dgi-db/pull/537