### PR TITLE
On search pages, group source dropdown into cancer-only and disease-agnostic sources

### DIFF
--- a/app/models/data_model/source.rb
+++ b/app/models/data_model/source.rb
@@ -33,6 +33,14 @@ module DataModel
         .sort
     end
 
+    def self.cancer_only_interaction_source_names
+      source_names_with_interactions.sort - disease_agnostic_interaction_source_names
+    end
+
+    def self.disease_agnostic_interaction_source_names
+      ["ChemblInteractions", "DrugBank", "DTC", "FDA", "GuideToPharmacology", "PharmGKB", "TdgClinicalTrial", "TEND", "TTD"]
+    end
+
     def self.source_names_with_interactions
       DataModel::SourceType.find(DataModel::SourceType.INTERACTION)
         .sources

--- a/app/models/data_model/source.rb
+++ b/app/models/data_model/source.rb
@@ -41,6 +41,14 @@ module DataModel
       ["ChemblInteractions", "DrugBank", "DTC", "FDA", "GuideToPharmacology", "PharmGKB", "TdgClinicalTrial", "TEND", "TTD"]
     end
 
+    def self.cancer_only_category_source_names
+      potentially_druggable_source_names.sort - disease_agnostic_category_source_names
+    end
+
+    def self.disease_agnostic_category_source_names
+      ["BaderLabGenes", "dGene", "GO", "GuideToPharmacology", "HingoraniCasas", "HopkinsGroom", "HumanProteinAtlas", "IDG", "Pharos", "RussLampel"]
+    end
+
     def self.source_names_with_interactions
       DataModel::SourceType.find(DataModel::SourceType.INTERACTION)
         .sources

--- a/app/views/static/search_categories.html.haml
+++ b/app/views/static/search_categories.html.haml
@@ -36,9 +36,18 @@
           %label
             Advanced Filters
           %div{style: "background-color: white; margin-top: 5px; padding: 5px; border-radius: 5px; height: 100px;"}
-            #source-control{style: "margin-top: 3px;"}
-              =render partial: 'shared/multiselect', locals: { control_group_name: 'Source Databases',
-                flag_text_key: 'sources_flag', select_tag_name: 'category_sources', collection: @sources.map{|s| s.rjust(s.length + 1)}, name_meth: 'strip', value_meth: 'to_s', tour_id: 'sources_tour' }
+            .control-group
+              .controls
+                Source Databases
+                %br
+                %select{name: "category_sources[]", id: "category_sources", multiple: "multiple", class: :multiselect, form: "search_form", style: "display: none;"}
+                  %optgroup{label: 'Cancer-Specific Sources'}
+                    -DataModel::Source.cancer_only_category_source_names.each do |name|
+                      %option(value="#{name}")= " #{name}"
+                  %optgroup{label: 'Disease-Agnostic Sources'}
+                    -DataModel::Source.disease_agnostic_category_source_names.each do |name|
+                      %option(value="#{name}")= " #{name}"
+                %div{style:'width:60px;', id: 'sources_tour'}
             -##source-trust-level
             -#  =render partial: 'shared/multiselect', locals: { control_group_name: 'Source Trust Level',
             -#    flag_text_key: 'source_trust_level_flag', select_tag_name: 'source_trust_levels', collection: @source_trust_levels, name_meth: 'to_s', value_meth: 'to_s', tour_id: 'source_trust_level_tour' }

--- a/app/views/static/search_interactions.html.haml
+++ b/app/views/static/search_interactions.html.haml
@@ -70,9 +70,18 @@
         %label
           Advanced Filters
         %div{style: "background-color: white; margin-top: 10px; padding: 5px; border-radius: 5px"} 
-          =render partial: 'shared/multiselect', locals: { control_group_name: 'Source Databases',
-            flag_text_key: 'source_database_flag', select_tag_name: 'interaction_sources', collection: @sources.map{|s| s.rjust(s.length + 1)},
-            name_meth: 'strip', value_meth: 'to_s', tour_id: 'sources_tour' }
+          .control-group
+            .controls
+              Source Databases
+              %br
+              %select{name: "interaction_sources[]", id: "interaction_sources", multiple: "multiple", class: :multiselect, form: "search_form", style: "display: none;"}
+                %optgroup{label: 'Cancer-Specific Sources'}
+                  -DataModel::Source.cancer_only_interaction_source_names.each do |name|
+                    %option(value="#{name}")= " #{name}"
+                %optgroup{label: 'Disease-Agnostic Sources'}
+                  -DataModel::Source.disease_agnostic_interaction_source_names.each do |name|
+                    %option(value="#{name}")= " #{name}"
+              %div{style:'width:60px;', id: 'sources_tour'}
           =render partial: 'shared/multiselect', locals: { control_group_name: 'Gene Categories',
             flag_text_key: 'gene_category_flag', select_tag_name: 'gene_categories', collection: @gene_categories.map{|s| s.rjust(s.length + 1)},
             name_meth: 'strip', value_meth: 'to_s', tour_id: 'gene_cateogories_tour' }

--- a/spec/features/search_categories_spec.rb
+++ b/spec/features/search_categories_spec.rb
@@ -18,10 +18,10 @@ describe 'search_categories' do
     visit '/search_categories'
 
     druggable_sources.each do |source|
-      expect(page).to have_content(source.source_db_name)
+      expect(page.body.include? source.source_db_name).to be true
     end
 
-    expect(page).not_to have_content(non_druggable_source.source_db_name)
+    expect(page.body.include? non_druggable_source.source_db_name).to be false
   end
 
   it 'should not display a list of source trust levels' do

--- a/spec/features/search_interactions_spec.rb
+++ b/spec/features/search_interactions_spec.rb
@@ -18,10 +18,10 @@ describe 'search_interactions' do
     visit '/search_interactions'
 
     interaction_sources.each do |source|
-      expect(page).to have_content(source.source_db_name)
+      expect(page.body.include? source.source_db_name).to be true
     end
 
-    expect(page).not_to have_content(other_source.source_db_name)
+    expect(page.body.include? other_source.source_db_name).to be false
   end
 
   it 'should display a list of gene categories' do


### PR DESCRIPTION
Closes #540 

<img width="635" alt="Screen Shot 2020-10-12 at 11 22 50 AM" src="https://user-images.githubusercontent.com/6617192/95771683-19e9cf80-0c81-11eb-9e60-83d53051b9db.png">
<img width="635" alt="Screen Shot 2020-10-12 at 11 23 00 AM" src="https://user-images.githubusercontent.com/6617192/95771695-1c4c2980-0c81-11eb-8c78-aec11df83707.png">
